### PR TITLE
Add basic support for responding to the "proceed direct" instruction

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -19,6 +19,7 @@
                 [applied-science/js-interop "0.2.7"]
                 [com.cemerick/url "0.1.1"]
                 [funcool/promesa "8.0.450"]
+                [re-frame-utils "0.1.0"]
 
                 ; dev tools:
                 [cider/cider-nrepl "0.24.0"]

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -40,7 +40,7 @@
 (defmethod dispatch-instruction
   :direct
   [craft context [_ fix-id]]
-  (if-let [fix (get-in context [:airport :navaids-by-id fix-id])]
+  (if-let [fix (get-in context [:game/navaids-by-id fix-id])]
     ; TODO this fix should probably already have its "world coordinates..."
     (do
       (radio! craft (str "direct " (:pronunciation fix) ", " (:callsign craft)))

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -8,6 +8,7 @@
    [clojure.string :as str]))
 
 (defn- radio! [^Aircraft craft message]
+  ; FIXME: We need to coalesce acks for all instructions into a single message...
   (>evt [:speech/enqueue {:message message
                           :from (assoc (:pilot craft)
                                        :name (:callsign craft))}]))
@@ -34,6 +35,18 @@
                        heading-str ", " (:callsign craft))))
   (update craft :commands assoc :heading heading :steer-direction steer-direction))
 
+(defmethod dispatch-instruction
+  :direct
+  [craft [_ fix-id]]
+  ; TODO We need to get the fix location out of the engine
+  (radio! craft (str "direct " fix-id ", " (:callsign craft)))
+  craft)
+
+(defmethod dispatch-instruction
+  :default
+  [craft [instruction]]
+  (println "TODO: Unhandled craft instruction: " instruction)
+  craft)
 
 ; ======= Physics =========================================
 

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -3,8 +3,8 @@
    [atc.data.aircraft-configs :as configs]
    [atc.engine.aircraft :as aircraft]
    [atc.engine.model :as engine-model :refer [Simulated tick]]
-   [atc.voice.process :refer [build-machine]]
-   [atc.voice.parsing.airport :as airport-parsing]))
+   [atc.voice.parsing.airport :as airport-parsing]
+   [atc.voice.process :refer [build-machine]]))
 
 (defn- dispatch-instructions [^Simulated simulated, context instructions]
   (when simulated
@@ -59,14 +59,6 @@
   (when-not (= 0 (:time-scale engine))
     (* 250 (/ 1 (:time-scale engine)))))
 
-(defn- index-airport [airport]
-  (assoc airport
-         :navaids-by-id (reduce
-                          (fn [m navaid]
-                            (assoc m (:id navaid) navaid))
-                          {}
-                          (:navaids airport))))
-
 (defn generate [airport]
   ; TODO: Probably, generate the parsing-machine elsewhere for better loading states
   (let [aircraft [["DAL22" configs/common-jet]]]
@@ -75,7 +67,7 @@
                        (assoc m callsign (aircraft/create config callsign)))
                      {}
                      aircraft)
-         :airport (index-airport airport)
+         :airport airport
          :parsing-machine (build-machine (airport-parsing/generate-parsing-context airport))
          :time-scale 1}
         (map->Engine))))

--- a/src/main/atc/engine/model.cljs
+++ b/src/main/atc/engine/model.cljs
@@ -52,5 +52,9 @@
 
 (defn bearing-to [from to]
   (let [{dx :x dy :y} (v- (vec3 to) from)]
-    (to-degrees (atan2 dy dx))))
+    ; NOTE: This may or may not be the right move, but We want 0 degrees to
+    ; point "north" on the screen, and so transform that in the Aircraft engine
+    ; object with `(- heading 90)`, which means we have to do the opposite
+    ; here....
+    (+ (to-degrees (atan2 dy dx)) 90)))
 

--- a/src/main/atc/engine/model.cljs
+++ b/src/main/atc/engine/model.cljs
@@ -1,4 +1,6 @@
-(ns atc.engine.model)
+(ns atc.engine.model
+  (:require
+   [clojure.math :refer [atan2 to-degrees]]))
 
 (defprotocol Simulated
   "Anything that is managed by the simulation"
@@ -12,6 +14,7 @@
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defprotocol Vector
   (v+ [this ^Vector other])
+  (v- [this ^Vector other])
   (v* [this other]))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
@@ -22,6 +25,12 @@
            :x (+ x (:x other))
            :y (+ y (:y other))
            :z (+ z (:z other 0))))
+
+  (v- [this ^Vec3 other]
+    (assoc this
+           :x (- x (:x other))
+           :y (- y (:y other))
+           :z (- z (:z other 0))))
 
   (v* [this other]
     (if (number? other)
@@ -35,5 +44,13 @@
              :y (* y (:y other))
              :z (* z (:z other 1))))))
 
-(defn vec3 [x y z]
-  (->Vec3 x y z))
+(defn vec3
+  ([v] (if (instance? Vec3 v) v
+         (->Vec3 (:x v) (:y v) (:z v))))
+  ([x y z]
+   (->Vec3 x y z)))
+
+(defn bearing-to [from to]
+  (let [{dx :x dy :y} (v- (vec3 to) from)]
+    (to-degrees (atan2 dy dx))))
+

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -107,12 +107,13 @@
                  {:ms delay-ms
                   :dispatch [:game/tick]}])]}))))
 
-(reg-event-db
+(reg-event-fx
   :game/reset
   [trim-v]
-  (fn [db _]
+  (fn [{:keys [db]} _]
     (println "Clear game engine")
-    (dissoc db :engine)))
+    {:db (dissoc db :engine)
+     :dispatch [:voice/stop!]}))
 
 (reg-event-fx
   :game/set-time-scale

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -3,7 +3,7 @@
    [atc.data.airports.kjfk :as kjfk]
    [atc.data.core :refer [local-xy]]
    [atc.db :as db]
-   [atc.engine.core :as engine :refer [engine-grammar]]
+   [atc.engine.core :as engine]
    [atc.engine.model :as engine-model]
    [goog.events.KeyCodes :as KeyCodes]
    [re-frame.core :refer [dispatch path reg-event-db reg-event-fx trim-v]]
@@ -182,7 +182,7 @@
   [trim-v]
   (fn [{:keys [db]} [result]]
     (println "voice/on-result" result)
-    {:voice/process {:machine (engine-grammar (:engine db))
+    {:voice/process {:machine (:parsing-machine (:engine db))
                      :input result}}))
 
 (reg-event-fx

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -34,16 +34,18 @@
   (->interceptor
     {:id :injected-engine
      :before (fn [context]
-               (let [ctx' (reduce
-                            (fn [ctx {:keys [before]}]
-                              (if before
-                                (before ctx)
-                                ctx))
-                            context
-                            engine-injections)]
-                 (update-coeffect ctx' :db
-                                  update :engine
-                                  merge-injections (get-coeffect ctx'))))
+               (let [context' (reduce
+                                (fn [ctx {:keys [before]}]
+                                  (if before
+                                    (before ctx)
+                                    ctx))
+                                context
+                                engine-injections)]
+                 (if (not= ::not-found (get (get-effect context' :db) :engine ::not-found))
+                   (update-coeffect context' :db
+                                    update :engine
+                                    merge-injections (get-coeffect context'))
+                   context')))
      :after (fn [context]
               (let [context' (reduce
                                (fn [ctx {:keys [after]}]

--- a/src/main/atc/fx.cljs
+++ b/src/main/atc/fx.cljs
@@ -55,9 +55,9 @@
 
 (reg-fx
   :voice/process
-  (fn [input]
+  (fn [{:keys [machine input]}]
     (println "Processing: " input)
-    (when-let [cmd (find-command input)]
+    (when-let [cmd (find-command machine input)]
       (>evt [:game/command cmd]))))
 
 

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -53,11 +53,20 @@
     (:airport engine)))
 
 (reg-sub
-  :game/airport-navaids
+  :game/navaids-by-id
   :<- [:game/airport]
   (fn [airport]
     (when airport
-      (->> airport
-           :navaids
-           (map (fn [{:keys [position] :as navaid}]
-                  (merge navaid (local-xy position airport))))))))
+      (reduce
+        (fn [m {:keys [position] :as navaid}]
+          (assoc m (:id navaid)
+                 (merge navaid (local-xy position airport))))
+        {}
+        (:navaids airport)))))
+
+(reg-sub
+  :game/airport-navaids
+  :<- [:game/navaids-by-id]
+  (fn [navaids]
+    (when navaids
+      (vals navaids))))

--- a/src/main/atc/views/game/controls.cljs
+++ b/src/main/atc/views/game/controls.cljs
@@ -42,10 +42,13 @@
         "Init Game"])
 
      (when game-running?
+       [:<>
        (if (= 0 time-scale)
          [:button {:on-click #(>evt [:game/set-time-scale 1])}
           "Resume"]
          [:button {:on-click #(>evt [:game/set-time-scale 0])}
-          "Pause"]))
+          "Pause"])
 
-     [voice-controls]]))
+       ; NOTE: We require a running game to initialize voice, since the voice grammar
+       ; depends on the airport
+       [voice-controls]])]))

--- a/src/main/atc/voice/core.cljs
+++ b/src/main/atc/voice/core.cljs
@@ -2,6 +2,7 @@
   (:require
    [applied-science.js-interop :as j]
    [archetype.util :refer [>evt]]
+   [atc.engine.core :refer [engine-grammar]]
    [atc.voice.mic :as mic]
    [atc.voice.recognizer :as recognizer]
    [promesa.core :as p]))
@@ -36,15 +37,15 @@
   (when-let [inst (::mic @client)]
     (mic/stop! inst)))
 
-(defn create [{:keys [on-partial-result on-result on-state use-grammar?]}]
+(defn create [{:keys [on-partial-result on-result on-state engine]}]
   (let [emit-state! (comp
                       #(p/delay 0) ; Let the UI update, if desired
                       (or on-state identity))
 
         _ (emit-state! :initializing) ; Do this before creating the recognizer
 
-        recognizer-inst (if use-grammar?
-                          (recognizer/create {:use-grammar? true})
+        recognizer-inst (if engine
+                          (recognizer/create {:grammar (engine-grammar engine)})
                           (recognizer/create))
         client (atom {::recognizer recognizer-inst})]
     (p/do!

--- a/src/main/atc/voice/grammar.cljs
+++ b/src/main/atc/voice/grammar.cljs
@@ -1,6 +1,5 @@
 (ns atc.voice.grammar
   (:require
-   [atc.voice.process :as process]
    [clojure.string :as str]))
 
 (defmulti generate-from-model (comp :tag :subject))
@@ -50,21 +49,19 @@
   nil)
 
 
-(defn from-command-model
-  ([] (from-command-model nil))
-  ([{:keys [model root-rule amount]
-     :or {root-rule :command
-          amount 10}}]
-   (let [model (or model (process/grammar))
-         generate-ctx {:root model
-                       :subject (get model root-rule)}]
-     (->> (range amount)
-          (map (fn [_] (->> (generate-from-model generate-ctx)
-                            (str/join " "))))))))
+(defn from-command-model [{:keys [model root-rule amount]
+                           :or {root-rule :command
+                                amount 10}}]
+  (let [generate-ctx {:root model
+                      :subject (get model root-rule)}]
+    (->> (range amount)
+         (map (fn [_] (->> (generate-from-model generate-ctx)
+                           (str/join " ")))))))
 
-(defn generate []
+(defn generate [command-model]
   (->> (concat
-         (from-command-model {:amount 200})
+         (from-command-model {:amount 200
+                              :model command-model})
          ["[unk]"])
        to-array
        (js/JSON.stringify)))

--- a/src/main/atc/voice/parsing/airport.cljc
+++ b/src/main/atc/voice/parsing/airport.cljc
@@ -1,8 +1,8 @@
-(ns atc.voice.parsing.aiport
+(ns atc.voice.parsing.airport
   (:require
    [atc.voice.parsing.core :refer [declare-alternates]]))
 
-(defn generate-parsing [airport]
+(defn generate-parsing-context [airport]
   (let [navaids-by-pronunciation (reduce
                                    (fn [m {:keys [pronunciation id]}]
                                      (assoc m pronunciation id))

--- a/src/main/atc/voice/parsing/airport.cljc
+++ b/src/main/atc/voice/parsing/airport.cljc
@@ -8,5 +8,5 @@
                                      (assoc m pronunciation id))
                                    {}
                                    (:navaids airport))]
-    {:rules [(declare-alternates "navaids" (map :pronunciation (:navaids airport)))]
-     :instructions {:navaids navaids-by-pronunciation}}))
+    {:rules [(declare-alternates "navaid" (map :pronunciation (:navaids airport)))]
+     :transformers {:navaid navaids-by-pronunciation}}))

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -15,6 +15,7 @@
    "<instruction> = standby
    | adjust-altitude
    | contact-other
+   | direct
    | steer"
 
    "standby = <'standby'>"
@@ -22,6 +23,8 @@
    "adjust-altitude = (<'climb'> | <'descend'>)? <'and'>? <'maintain'> altitude"
 
    "contact-other = <'contact'> other-position <frequency>? pleasantry?"
+
+   "direct = <'proceed direct'> navaid"
 
    "steer = (<'fly'> | 'turn right' | 'turn left') <'heading'> heading"
 

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -1,6 +1,16 @@
 (ns atc.voice.process-test
-  (:require [cljs.test :refer-macros [deftest is testing]]
-            [atc.voice.process :refer [find-command]]))
+  (:require
+   [atc.data.airports.kjfk :as kjfk]
+   [atc.voice.parsing.airport :as airport-parsing]
+   [atc.voice.process :rename {find-command actual-find-command} :refer [build-machine]]
+   [cljs.test :refer-macros [deftest is testing]]))
+
+(def machine
+  (delay
+    (build-machine (airport-parsing/generate-parsing-context kjfk/airport))))
+
+(defn find-command [input]
+  (actual-find-command @machine input))
 
 (defn find-instructions [input]
   (-> input

--- a/src/main/atc/voice/recognizer.cljs
+++ b/src/main/atc/voice/recognizer.cljs
@@ -43,7 +43,7 @@
 
 (defn create
   ([] (create nil))
-  ([{:keys [sample-rate use-grammar?] :or {sample-rate const/default-sample-rate}}]
+  ([{:keys [sample-rate grammar] :or {sample-rate const/default-sample-rate}}]
    (let [client (atom nil)]
      (swap!
        client
@@ -52,9 +52,9 @@
        (p/let [start (js/Date.now)
                model @shared-model
                KaldiRecognizer (j/get model :KaldiRecognizer)
-               grammar-content (when use-grammar?
-                                 (println "Generating grammar...")
-                                 (time (grammar/generate)))
+               grammar-content (when grammar
+                                 (println "Generating grammar..." grammar)
+                                 (time (grammar/generate grammar)))
                recognizer (if (some? grammar-content)
                             (new KaldiRecognizer sample-rate grammar-content)
                             (new KaldiRecognizer sample-rate))]


### PR DESCRIPTION
- Refactor to attach the parsing machine to the Engine
- Fix grammar dispatch; support parsing "direct FIX" instruction
- Hide the voice UI unless a game exists
- Cheekily pass through the engine context using metadata
- Add a very janky "steer direct towards" command handling
- Inject subscriptions into the Engine for dispatches
- Fix "direct" steering by reversing the bearing/heading normalization
- Fix injected-engine to not inject garbage into a nil engine
