### PR TITLE
Track previous engine states and render aircraft position history

### DIFF
--- a/src/main/atc/db.cljs
+++ b/src/main/atc/db.cljs
@@ -1,8 +1,14 @@
-(ns atc.db)
+(ns atc.db
+  (:require
+   [atc.structures.rolling-history :refer [rolling-history]]))
+
+(def max-game-snapshots 60) ; ~4 minutes
 
 (def default-db
   ; NOTE: default to game, for now
   {:page [:game]
+
+   :game-history (rolling-history max-game-snapshots)
 
    :speech {:available? nil
             :speaking? false

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -17,7 +17,7 @@
       simulated)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defrecord Engine [airport aircraft parsing-machine time-scale last-tick]
+(defrecord Engine [airport aircraft parsing-machine time-scale elapsed-s last-tick]
   ; NOTE: It is sort of laziness that we're implementing Simulated here,
   ; since we aren't, properly. Technically we should have a separate Simulator
   ; protocol and implement that to be more correct...
@@ -39,6 +39,7 @@
 
       (assoc this
              :aircraft updated-aircraft
+             :elapsed-s (+ (:elapsed-s this) dt)
              :last-tick (when-not (= 0 time-scale)
                           now))))
 
@@ -69,5 +70,6 @@
                      aircraft)
          :airport airport
          :parsing-machine (build-machine (airport-parsing/generate-parsing-context airport))
+         :elapsed-s 0
          :time-scale 1}
         (map->Engine))))

--- a/src/main/atc/structures/rolling_history.cljs
+++ b/src/main/atc/structures/rolling_history.cljs
@@ -1,0 +1,47 @@
+(ns atc.structures.rolling-history
+  (:require [cljs.core :refer [APersistentVector]]))
+
+(defprotocol IHistorical
+  (-most-recent-n [coll n] "Like take-last but O(1)"))
+
+(deftype RollingHistory [^APersistentVector -vec max-count]
+  ICollection
+  (-conj [_this v]
+    (let [new-vec (if (>= (count -vec) max-count)
+                    (conj (subvec -vec 1) v)
+                    (conj -vec v))]
+      (RollingHistory. new-vec max-count)))
+
+  IEmptyableCollection
+  (-empty [_this] (RollingHistory. (empty -vec) max-count))
+
+  IStack
+  (-peek [_this]
+    (peek -vec))
+  (-pop [this]
+    (when-not (= 0 (count this))
+      (RollingHistory. (pop -vec) max-count)))
+
+  ICounted
+  (-count [_this]
+    (count -vec))
+
+  ISeqable
+  (-seq [_this]
+    (seq -vec))
+
+  IHistorical
+  (-most-recent-n [_this n]
+    (let [start (max 0 (- (count -vec) n))]
+      (subvec -vec start)))
+
+  IPrintWithWriter
+  (-pr-writer [_this writer opts]
+    (-write writer "#history ")
+    (-pr-writer -vec writer opts)))
+
+(defn most-recent-n [n ^IHistorical history]
+  (-most-recent-n history n))
+
+(defn rolling-history [max-count]
+  (->RollingHistory [] max-count))

--- a/src/main/atc/views/game.cljs
+++ b/src/main/atc/views/game.cljs
@@ -34,10 +34,15 @@
       [render entity]])])
 
 (defn- all-aircraft [scale]
-  [entities-renderer {:scale scale
-                      :<sub [:game/aircraft]
-                      :key-fn :callsign
-                      :render aircraft/entity}])
+  [:<>
+   [entities-renderer {:scale scale
+                       :<sub [:game/aircraft-historical]
+                       :key-fn (juxt :history-n :callsign)
+                       :render aircraft/entity-historical}]
+   [entities-renderer {:scale scale
+                       :<sub [:game/aircraft]
+                       :key-fn :callsign
+                       :render aircraft/entity}]])
 
 (defn- all-navaids [scale]
   [entities-renderer {:scale scale

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -26,3 +26,13 @@
 (defn entity [{:keys [callsign]}]
   ; TODO render different graphics based on aircraft state
   [tracked callsign])
+
+(defn entity-historical [_entity]
+  ; TODO Can we do this in a more composable way?
+  [:> px/Text {:text "⬤"
+               :anchor 0.5
+               :x 0
+               :y 0
+               :alpha 0.3
+               :style tracked-aircraft-style}])
+


### PR DESCRIPTION
This PR introduces a new vector-powered data structure which provides a persistent queue of the most-recent M inserted items (with the "oldest" entries ejected as necessary) with fast read access to the N most recent entries. We then use this structure to render the "path" that aircraft have recently taken.

If we wanted to, in the future we could use this to roll back time, which could be neat