### PR TITLE
Add rough support for ILS approaches

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -18,6 +18,13 @@
  :lint-as {applied-science.js-interop/defn clojure.core/defn
            applied-science.js-interop/let clojure.core/let
            applied-science.js-interop/fn clojure.core/fn
+
+           com.rpl.specter/defcollector clojure.core/defn
+           com.rpl.specter/defdynamicnav clojure.core/defn
+           com.rpl.specter/defmacroalias clojure.core/def
+           com.rpl.specter/defnav clojure.core/defn
+           com.rpl.specter/defrichnav clojure.core/defn
+
            gloss.core/defcodec clojure.core/def
            instaparse.core/defparser clojure.core/def
            promesa.core/let clojure.core/let

--- a/src/main/atc/data/aircraft_configs.cljs
+++ b/src/main/atc/data/aircraft_configs.cljs
@@ -5,4 +5,7 @@
 (def common-jet (aircraft-config/create
                   ; NOTE: 3 degrees per second is a standard rate turn
                   ; see: https://en.wikipedia.org/wiki/Standard_rate_turn
-                  {:turn-rate 3}))
+                  {:turn-rate 3
+
+                   :climb-rate 3000
+                   :descent-rate 3500}))

--- a/src/main/atc/data/airports.cljc
+++ b/src/main/atc/data/airports.cljc
@@ -1,6 +1,8 @@
 (ns atc.data.airports 
   (:require
-   [atc.data.core :refer [local-xy]]))
+   [atc.data.core :refer [local-xy]]
+   [atc.data.units :refer [ft->m]]
+   [atc.engine.model :refer [vec3]]))
 
 (defn runway-coords [airport runway]
   (when-let [runway-object (->> airport
@@ -8,8 +10,13 @@
                                 (filter #(or (= runway (:start-id %))
                                              (= runway (:end-id %))))
                                 first)]
-    (let [start (local-xy (:start-threshold runway-object) airport)
-          end (local-xy (:end-threshold runway-object) airport)]
+    (let [elevation (-> (:position airport)
+                        (nth 2)
+                        ft->m)
+          start (-> (local-xy (:start-threshold runway-object) airport)
+                    (vec3 elevation))
+          end (-> (local-xy (:end-threshold runway-object) airport)
+                  (vec3 elevation))]
       (if (= (:start-id runway-object) runway)
         [start end]
         [end start]))))

--- a/src/main/atc/data/airports.cljc
+++ b/src/main/atc/data/airports.cljc
@@ -1,0 +1,15 @@
+(ns atc.data.airports 
+  (:require
+   [atc.data.core :refer [local-xy]]))
+
+(defn runway-coords [airport runway]
+  (when-let [runway-object (->> airport
+                                :runways
+                                (filter #(or (= runway (:start-id %))
+                                             (= runway (:end-id %))))
+                                first)]
+    (let [start (local-xy (:start-threshold runway-object) airport)
+          end (local-xy (:end-threshold runway-object) airport)]
+      (if (= (:start-id runway-object) runway)
+        [start end]
+        [end start]))))

--- a/src/main/atc/data/units.cljc
+++ b/src/main/atc/data/units.cljc
@@ -1,7 +1,18 @@
-(ns atc.data.units)
+(ns atc.data.units 
+  (:require
+   [clojure.math :refer [floor]]))
+
+(defn m->ft [meters]
+  ; NOTE: We probably *never* need to do this except for displaying
+  ; or verbally reporting an aircraft's altitude in feet, so let's
+  ; just make it clean:
+  (floor (* 3.28084 meters)))
 
 (defn m->nm [meters]
   (* 0.000539957 meters))
+
+(defn ft->m [feet]
+  (* 0.3048 feet))
 
 (defn nm->m [nautical-miles]
   (* 1852 nautical-miles))

--- a/src/main/atc/data/units.cljc
+++ b/src/main/atc/data/units.cljc
@@ -1,0 +1,7 @@
+(ns atc.data.units)
+
+(defn m->nm [meters]
+  (* 0.000539957 meters))
+
+(defn nm->m [nautical-miles]
+  (* 1852 nautical-miles))

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -1,5 +1,6 @@
 (ns atc.engine.aircraft
   (:require
+   [atc.data.units :refer [ft->m]]
    [atc.engine.aircraft.commands :refer [apply-commanded-inputs]]
    [atc.engine.aircraft.instructions :as instructions :refer [dispatch-instruction]]
    [atc.engine.config :refer [AircraftConfig]]
@@ -64,7 +65,7 @@
                   :radio-name radio-name
                   :state :flight
                   :pilot (pilot/generate nil) ; TODO Pass in a preferred voice?
-                  :position (vec3 250 250 20000)
+                  :position (vec3 250 250 (ft->m 20000))
                   :heading 350
                   :speed 200
                   :commands {:heading 90}}))

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -8,6 +8,9 @@
     (+ h 360)
     (mod h 360)))
 
+
+; ======= Steering ========================================
+
 (defn shorter-steer-direction [from to]
   ; With thanks to: https://math.stackexchange.com/a/2898118
   (let [delta (- (mod (- to from -540)
@@ -35,8 +38,11 @@
               (* turn-amount 0.5))
         (-> aircraft
             (assoc :heading commanded-to)  ; close enough; snap to
-            (dissoc :steer-direction))
+            (update :commands dissoc :steer-direction))
         (assoc aircraft :heading new-heading)))))
+
+
+; ======= Direct-to-point nav =============================
 
 (defn- apply-direct [aircraft commanded-to dt]
   ; NOTE: This is temporary; the real logic should account for resuming course,
@@ -45,9 +51,40 @@
     (apply-steering aircraft bearing-to-destination dt)))
 
 
+; ======= Approach course following =======================
+
+(defn- within-localizer? [_aircraft _airport _runway]
+  ; TODO Let's math.
+  true)
+
+(defn- apply-ils-approach [aircraft {:keys [airport runway]} dt]
+  (if (within-localizer? aircraft airport runway)
+    (-> aircraft
+
+        ; We no longer need to maintain any specific heading
+        (update :commands dissoc :heading :steer-direction)
+
+        ; Steer toward the airport
+        ; TODO: Perhaps, steer toward runway threshold? Or, maintain its heading? There's
+        ; definitely a more realistic approach than either of these, but this may be
+        ; sufficient for now...
+        ; TODO: Follow glide slope
+        ; TODO: Detect "landing"
+        (apply-direct airport dt))
+
+      ; Just proceed on course
+      aircraft))
+
+; I suppose this could be a defmulti...
+(defn- apply-approach [aircraft {:keys [approach-type] :as command} dt]
+  (case approach-type
+    :ils (apply-ils-approach aircraft command dt)))
+
+
 ; ======= Publc interface =================================
 
 (defn apply-commanded-inputs [aircraft, commands dt]
   (cond-> aircraft
     (:heading commands) (apply-steering (:heading commands) dt)
-    (:direct commands) (apply-direct (:direct commands) dt)))
+    (:direct commands) (apply-direct (:direct commands) dt)
+    (:cleared-approach commands) (apply-approach (:cleared-approach commands) dt)))

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -24,6 +24,19 @@
             (utter "cleared approach runway" [:runway runway]))))
 
 (defmethod dispatch-instruction
+  :cancel-approach
+  [craft _ _]
+  (cond
+    ; If not currently cleared, this is a nop:
+    (not (get-in craft [:commands :cleared-approach]))
+    craft
+
+    :else (-> craft
+            (assoc :state :flight)
+            (update :commands dissoc :cleared-approach)
+            (utter "cancel approach"))))
+
+(defmethod dispatch-instruction
   :steer
   [craft _ [_ heading steer-direction]]
   ; TODO Check state; if in approach, we should reject

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -17,11 +17,16 @@
 
     :else (-> craft
             (assoc :state :cleared-approach)
+            (update :commands dissoc :direct)
+            (update :commands assoc :cleared-approach {:approach-type approach-type
+                                                       :airport (:airport context)
+                                                       :runway runway})
             (utter "cleared approach runway" [:runway runway]))))
 
 (defmethod dispatch-instruction
   :steer
   [craft _ [_ heading steer-direction]]
+  ; TODO Check state; if in approach, we should reject
   (-> craft
       (utter (when steer-direction (name steer-direction))
              [:heading heading])
@@ -32,6 +37,7 @@
 (defmethod dispatch-instruction
   :direct
   [craft context [_ fix-id]]
+  ; TODO Check state; if in approach, we should reject
   (if-let [fix (get-in context [:game/navaids-by-id fix-id])]
     (-> craft
         (utter "direct " fix)

--- a/src/main/atc/engine/config.cljs
+++ b/src/main/atc/engine/config.cljs
@@ -1,8 +1,12 @@
-(ns atc.engine.config)
+(ns atc.engine.config
+  (:require
+   [atc.data.units :as units]))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defrecord AircraftConfig [turn-rate])
+(defrecord AircraftConfig [turn-rate climb-rate descent-rate])
 
 (defn create [kvs]
-  (map->AircraftConfig kvs))
+  (-> kvs
+      (update :climb-rate units/ft->m)
+      (update :descent-rate units/ft->m)
+      (map->AircraftConfig)))
 

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -1,6 +1,6 @@
 (ns atc.engine.model
   (:require
-   [clojure.math :refer [atan2 sqrt to-degrees]]))
+   [clojure.math :refer [atan2 to-degrees]]))
 
 (defprotocol Simulated
   "Anything that is managed by the simulation"
@@ -60,6 +60,8 @@
 (defn vec3
   ([v] (if (instance? Vec3 v) v
          (->Vec3 (:x v) (:y v) (:z v))))
+  ([v z] (let [{:keys [x y]} (vec3 v)]
+           (->Vec3 x y z)))
   ([x y z]
    (->Vec3 x y z)))
 

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -76,3 +76,16 @@
     ; here....
     (+ (to-degrees (atan2 dy dx)) 90)))
 
+(defn angle-down-to
+  "Assuming `from` is an elevated position and `to` is a position on the ground,
+  return the angle between the ground and a line segment between `from` and `to`"
+  [from to]
+  (let [from (vec3 from)
+        to (vec3 to)
+        elevation (- (:z from) (:z to))]
+    (to-degrees
+      ; NOTE: Rather than involve any sqrts we just square elevation
+      (atan2 (* elevation elevation)
+             (vmag2
+               (v- (vec3 from 0)
+                   (vec3 to 0)))))))

--- a/src/main/atc/engine/model.cljs
+++ b/src/main/atc/engine/model.cljs
@@ -1,6 +1,6 @@
 (ns atc.engine.model
   (:require
-   [clojure.math :refer [atan2 to-degrees]]))
+   [clojure.math :refer [atan2 sqrt to-degrees]]))
 
 (defprotocol Simulated
   "Anything that is managed by the simulation"
@@ -21,7 +21,8 @@
 (defprotocol Vector
   (v+ [this ^Vector other])
   (v- [this ^Vector other])
-  (v* [this other]))
+  (v* [this other])
+  (vmag2 [this] "Compute the square of the magnitude of this vector"))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defrecord Vec3 [x y z]
@@ -48,13 +49,22 @@
       (assoc this
              :x (* x (:x other))
              :y (* y (:y other))
-             :z (* z (:z other 1))))))
+             :z (* z (:z other 1)))))
+
+  (vmag2 [this]
+    (let [{dx :x dy :y dz :z} this]
+      (+ (* dx dx)
+         (* dy dy)
+         (* dz dz)))))
 
 (defn vec3
   ([v] (if (instance? Vec3 v) v
          (->Vec3 (:x v) (:y v) (:z v))))
   ([x y z]
    (->Vec3 x y z)))
+
+(defn distance-to-squared [from to]
+  (vmag2 (v- (vec3 to) from)))
 
 (defn bearing-to [from to]
   (let [{dx :x dy :y} (v- (vec3 to) from)]

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -108,6 +108,9 @@
   (fn [{:keys [db]} _]
     (when-let [engine (:engine db)]
       (let [engine' (engine-model/tick engine nil)
+            new-events (:events engine)
+            engine' (assoc engine' :events nil)
+
             db' (assoc db :engine engine')
 
             seconds-since-last-snapshot (- (:elapsed-s engine')
@@ -118,7 +121,10 @@
          :fx [(when-let [delay-ms (engine/next-tick-delay engine')]
                 [:dispatch-later
                  {:ms delay-ms
-                  :dispatch [:game/tick]}])]}))))
+                  :dispatch [:game/tick]}])
+
+              (when (seq new-events)
+                (println "TODO: Handle engine events:" new-events))]}))))
 
 (reg-event-fx
   :game/reset

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -56,7 +56,8 @@
 
 (def ^:private walk-speakables
   ; Might be nice to properly lint this macro:
-  #_{:clj-kondo/ignore [:unresolved-symbol]}
+  ; Specter is really hard for kondo to lint...
+  #_{:clj-kondo/ignore [:unresolved-symbol :unresolved-var]}
   (s/recursive-path []
     p
     (s/cond-path

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -17,6 +17,7 @@
    "adjust-altitude = (<'climb'> | <'descend'>)? <'and'>? <'maintain'> altitude"
 
    "cleared-approach = <'cleared'> approach-type <'approach'>? <'runway'>? runway <'approach'>?"
+   "cancel-approach = <'cancel approach clearance'>"
 
    "contact-other = <'contact'> other-position <frequency>? pleasantry?"
 

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -34,7 +34,7 @@
                                   (str/join " | ")))
 
      "approach-type = 'i l s' | 'r nav' | 'visual'"
-     "runway = number+ (letter | 'left' | 'right' | 'north' | 'south')?"
+     "runway = number-sequence (letter | 'left' | 'right' | 'north' | 'south')?"
      (declare-alternates "other-position" handoffs)
      (declare-alternates "pleasantry" pleasantries)]
     instructions-rules))
@@ -56,8 +56,7 @@
 
    :other-position keyword
 
-   :runway (fn [& parts]
-             (let [numbers (butlast parts)
-                   position (last parts)]
-               (str (str/join numbers)
+   :runway (fn [numbers position]
+             (str (str/join numbers)
+                  (when position
                     (str/upper-case (first position)))))})

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -17,7 +17,7 @@
    "adjust-altitude = (<'climb'> | <'descend'>)? <'and'>? <'maintain'> altitude"
 
    "cleared-approach = <'cleared'> approach-type <'approach'>? <'runway'>? runway <'approach'>?"
-   "cancel-approach = <'cancel approach clearance'>"
+   "cancel-approach = <'cancel'> <'approach clearance'>"
 
    "contact-other = <'contact'> other-position <frequency>? pleasantry?"
 

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -60,7 +60,10 @@
   (testing "Clear ILS approach to runway"
     (is (= [[:cleared-approach :ils "30L"]]
            (find-instructions
-             "piper one cleared i l s runway tree zero left approach"))))
+             "piper one cleared i l s runway tree zero left approach")))
+    (is (= [[:cleared-approach :ils "22"]]
+           (find-instructions
+             "piper one cleared i l s runway two two approach"))))
    (testing "Clear visual approach to runway"
     (is (= [[:cleared-approach :visual "30L"]]
            (find-instructions


### PR DESCRIPTION
This is all *very* rough and mostly placeholder-y but lays a lot of groundwork.

- Add hacky initial approach steering implementation
- Begin work to detect whether an aircraft is intercepting the localizer
- Include elevation in runway-coords
- Attempt to detect glide slope
- Attempt to update altitude when on glide slope to approach runway
- Implement "cancel approach clearance" command
- Fix runway parsing
- Add *rough* support for handling aircraft landing
