### PR TITLE
Support altitude commands

### DIFF
--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -56,7 +56,7 @@
 
 ; ======= Altitude ========================================
 
-(defn- apply-altitude [{from :altitude :as aircraft} commanded-altitude dt]
+(defn- apply-altitude [{{from :z} :position :as aircraft} commanded-altitude dt]
   (if (= from commanded-altitude)
     aircraft
 
@@ -68,11 +68,11 @@
       (if (<= (abs (- commanded-altitude new-altitude))
               (* rate 0.5))
         (-> aircraft
-            (assoc :altitude commanded-altitude)  ; close enough; snap to
+            (assoc-in [:position :z] commanded-altitude)  ; close enough; snap to
             (update :commands dissoc :target-altitude))
 
         (-> aircraft
-            (assoc :altitude new-altitude))))))
+            (assoc-in [:position :z] new-altitude))))))
 
 
 ; ======= Approach course following =======================

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -157,4 +157,5 @@
   (cond-> aircraft
     (:heading commands) (apply-steering (:heading commands) dt)
     (:direct commands) (apply-direct (:direct commands) dt)
-    (:cleared-approach commands) (apply-approach (:cleared-approach commands) dt)))
+    (:cleared-approach commands) (apply-approach (:cleared-approach commands) dt)
+    (:target-altitude commands) (apply-altitude (:target-altitude commands) dt)))

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -1,9 +1,19 @@
-(ns atc.engine.aircraft.instructions)
+(ns atc.engine.aircraft.instructions
+  (:require
+   [atc.data.units :as units]))
 
 (defn- utter [craft & utterance]
   (update craft ::utterance-parts conj utterance))
 
 (defmulti dispatch-instruction (fn [_craft _context [instruction]] instruction))
+
+(defmethod dispatch-instruction
+  :adjust-altitude
+  [craft _ [_ altitude]]
+  ; TODO Check state; if in approach, we should reject
+  (-> craft
+      (update :commands assoc :target-altitude (units/ft->m altitude))
+      (utter "maintain" [:altitude altitude])))
 
 (defmethod dispatch-instruction
   :cleared-approach

--- a/src/main/atc/engine/config.cljs
+++ b/src/main/atc/engine/config.cljs
@@ -4,9 +4,15 @@
 
 (defrecord AircraftConfig [turn-rate climb-rate descent-rate])
 
+(defn- ft-m->m-s [ft-m]
+  (/ (units/ft->m ft-m) 60))
+
 (defn create [kvs]
   (-> kvs
-      (update :climb-rate units/ft->m)
-      (update :descent-rate units/ft->m)
+
+      ; Input for these is ft/minute; convert to m/s
+      (update :climb-rate ft-m->m-s)
+      (update :descent-rate ft-m->m-s)
+
       (map->AircraftConfig)))
 

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -8,6 +8,24 @@
 
 (defmulti ^:private process-speakable (fn [[kind _]] kind))
 
+(defmethod process-speakable :altitude
+  [[_ v]]
+  ; 20000 -> 2 0 thousand
+  (cond
+    (>= v 10000)
+    (let [s (str v)]
+      [(first s)
+       (second s)
+       "thousand"])
+
+    :else
+    (-> v str)))
+
+(defmethod process-speakable :heading
+  [[_ v]]
+  ; TODO 040 might come in as the int 40
+  (-> v str seq))
+
 (defmethod process-speakable :runway
   [[_ string]]
   (->> string
@@ -19,11 +37,6 @@
                 \N "north"
                 \S "south"
                 v)))))
-
-(defmethod process-speakable :heading
-  [[_ v]]
-  ; TODO 040 might come in as the int 40
-  (-> v str seq))
 
 (defmethod process-speakable :default [v]
   (println "WARNING: Unknown speakable kind format:" v))

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -24,10 +24,15 @@
   (str/join "  " line))
 
 (defn format-altitude [altitude-meters]
-  (-> altitude-meters
-      units/m->ft
-      (/ 100)
-      (floor)))
+  (loop [s (str (-> altitude-meters
+                    units/m->ft
+                    (/ 100)
+                    (floor)))]
+
+    ; Pad-left with 0
+    (if (>= 3 (count s))
+      s
+      (recur (str "0" s)))))
 
 
 ; ======= Rendering =======================================
@@ -52,10 +57,8 @@
 (defn- full-data-block [{:keys [callsign position speed]}]
   (let [alt-hundreds-ft (format-altitude (:z position))
 
-        speed-kts speed ; TODO
-
         line1 [callsign]
-        line2 [alt-hundreds-ft speed-kts]]
+        line2 [alt-hundreds-ft speed]]
     [:> px/Text {:text (str (format-data-block-line line1)
                             "\n"
                             (format-data-block-line line2))

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -1,34 +1,98 @@
 (ns atc.views.game.graphics.aircraft
   (:require
    ["@inlet/react-pixi" :as px]
-   ["pixi.js" :refer [TextStyle]]))
+   ["pixi.js" :refer [TextStyle]]
+   [atc.data.units :as units]
+   [atc.views.game.graphics.line :refer [line]]
+   [clojure.math :refer [floor]]
+   [clojure.string :as str]))
 
-(def label-style (TextStyle. #js {:fill "#00ff00" ; TODO
-                                  :fontSize 12}))
+(def tracked-label-style (TextStyle. #js {:fill "#ffffff"
+                                          :fontFamily "monospace"
+                                          :fontSize 12}))
 
 (def tracked-aircraft-style (TextStyle. #js {:fill "#1f478f"
                                              :fontSize 8}))
 
-(defn- tracked [callsign]
+(def untracked-aircraft-style (TextStyle. #js {:fill "#00ff00"
+                                               :fontSize 8}))
+
+; ======= Data formatting =================================
+
+(defn- format-data-block-line [line]
+  ; FIXME
+  (str/join "  " line))
+
+(defn format-altitude [altitude-meters]
+  (-> altitude-meters
+      units/m->ft
+      (/ 100)
+      (floor)))
+
+
+; ======= Rendering =======================================
+
+(defn- data-block-positioning [_craft block]
+  [:<>
+   ; TODO choose color based on tracked state
+   [line {:from {:x 10 :y 0}
+          :to {:x 20 :y 0}
+          :color 0xffffff}]
+
+   [:> px/Container {:x 55 :y 0}
+    block]])
+
+(defn- tracked-position-symbol []
+  [:> px/Text {:text "⬤"
+               :anchor 0.5
+               :x 0
+               :y 0
+               :style tracked-aircraft-style}])
+
+(defn- full-data-block [{:keys [callsign position speed]}]
+  (let [alt-hundreds-ft (format-altitude (:z position))
+
+        speed-kts speed ; TODO
+
+        line1 [callsign]
+        line2 [alt-hundreds-ft speed-kts]]
+    [:> px/Text {:text (str (format-data-block-line line1)
+                            "\n"
+                            (format-data-block-line line2))
+                 :anchor 0.5
+                 :x 0
+                 :style tracked-label-style}]))
+
+(defn- tracked [craft]
   ; TODO: Adjust label location?
   [:<>
-   [:> px/Text {:text "⬤"
+   [tracked-position-symbol]
+
+   [data-block-positioning craft
+    [full-data-block craft]]])
+
+(defn- untracked [{{altitude :z} :position :as craft}]
+  [:<>
+   [:> px/Text {:text "*"
                 :anchor 0.5
                 :x 0
                 :y 0
-                :style tracked-aircraft-style}]
-   (when callsign
-     [:> px/Text {:text callsign
-                  :anchor 0.5
-                  :x 0
-                  :y 20
-                  :style label-style}])])
+                :style untracked-aircraft-style}]
+   [data-block-positioning craft
+    [:> px/Text {:text (format-altitude altitude)
+                 :style untracked-aircraft-style}]]])
 
-(defn entity [{:keys [callsign]}]
+
+; ======= Public interface ================================
+
+(defn entity [{:keys [callsign] :as craft}]
   ; TODO render different graphics based on aircraft state
-  [tracked callsign])
+  ; TODO "tracked" vs "untracked" state
+  (if callsign
+    [tracked craft]
+    [untracked craft]))
 
 (defn entity-historical [_entity]
   [:> px/Container {:alpha 0.3}
-   [entity nil]])
+   [tracked-position-symbol]])
 

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -20,8 +20,8 @@
 ; ======= Data formatting =================================
 
 (defn- format-data-block-line [line]
-  ; FIXME
-  (str/join "  " line))
+  ; TODO Should we to some length...?
+  (str/join " " line))
 
 (defn format-altitude [altitude-meters]
   (loop [s (str (-> altitude-meters

--- a/src/main/atc/views/game/graphics/line.cljs
+++ b/src/main/atc/views/game/graphics/line.cljs
@@ -1,0 +1,13 @@
+(ns atc.views.game.graphics.line
+  (:require
+   ["@inlet/react-pixi" :as px]))
+
+(defn line [{:keys [from to width color alpha]
+             :or {width 1
+                  alpha 1}}]
+  [:> px/Graphics {:draw (fn draw [^js g]
+                           (doto g
+                             (.clear)
+                             (.lineStyle width color alpha)
+                             (.moveTo (:x from) (:y from))
+                             (.lineTo (:x to) (:y to))))}])


### PR DESCRIPTION
This PR implements support for the "climb/descend and maintain" instructions, as well as updates the datablock rendering to include altitude (in 100's of ft) and ground speed (in kts).

It also fixes the `(apply-altitude)` proc that was introduced previously to actually work (oops)

- Support the adjust-altitude instruction
- Fix: actually updated `[:position :z]` in apply-altitude
