### PR TITLE
Support spelling out navaids

### DIFF
--- a/src/main/atc/voice/parsing/airport.cljc
+++ b/src/main/atc/voice/parsing/airport.cljc
@@ -12,5 +12,10 @@
                                             id))
                                    {}
                                    (:navaids airport))]
-    {:rules [(declare-alternates "navaid" (keys navaids-by-pronunciation))]
-     :transformers {:navaid navaids-by-pronunciation}}))
+    {:rules ["<navaid> = navaid-pronounced | navaid-spelled"
+             "navaid-spelled = (letter letter letter <'v o r'>?) | (letter letter letter letter letter <'intersection'>?)"
+
+             (declare-alternates "navaid-pronounced" (keys navaids-by-pronunciation))]
+     :transformers {:navaid-pronounced navaids-by-pronunciation
+                    :navaid-spelled (fn [& letters]
+                                      (str/join letters))}}))

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -50,6 +50,24 @@
                 (pop instructions)))
          (is (= :error (-> instructions last first)))))))
 
+(deftest navaid-test
+  (testing "Pronounceable navaids"
+    (is (= [[:direct "MERIT"]]
+           (find-instructions
+             "piper one proceed direct merit"))))
+
+  (testing "Spelled navaids"
+    (is (= [[:direct "BDR"]]
+           (find-instructions
+             "piper one proceed direct bravo delta romeo v o r")
+           (find-instructions
+             "piper one proceed direct bravo delta romeo")))
+     (is (= [[:direct "TOWIN"]]
+           (find-instructions
+             "piper one proceed direct tango oscar whiskey india november")
+           (find-instructions
+             "piper one proceed direct tango oscar whiskey india november intersection")))))
+
 (deftest steer-test
   (testing "Process steer direction"
     (is (= [[:steer 985 :right]]


### PR DESCRIPTION
This implements #10

Even if we can come up with pronounceable versions of every navaid name, many folks will probably not know the name and being able to just spell it out phonetically is nice. 