### PR TITLE
Improve navaid pronounceability

### DIFF
--- a/src/main/atc/data/airports/kjfk.cljc
+++ b/src/main/atc/data/airports/kjfk.cljc
@@ -25,18 +25,20 @@
   :navaids
   [{:id "ACOVE",
     :position [:N42*14'05.220 :W074*01'54.590],
-    :type :fix}
+    :type :fix,
+    :pronunciation "ac ove"}
    {:id "AGNEZ",
     :position [:N42*13'32.710 :W074*11'18.750],
-    :type :fix}
+    :type :fix,
+    :pronunciation "agnes"}
    {:id "ALB",
     :position [:N42*44'50.210 :W073*48'11.462],
     :type :vortac,
-    :pronunciation "albany"}
+    :name "albany"}
    {:id "ARD",
     :position [:N40*15'12.033 :W074*54'27.405],
     :type :vor/dme,
-    :pronunciation "yardley"}
+    :name "yardley"}
    {:id "ASPEN",
     :position [:N42*48'57.550 :W070*54'41.390],
     :type :fix}
@@ -45,111 +47,131 @@
     :type :fix}
    {:id "BAYYS",
     :position [:N41*17'21.270 :W072*58'16.730],
-    :type :fix}
+    :type :fix,
+    :pronunciation "bays"}
    {:id "BDR",
     :position [:N41*09'38.540 :W073*07'28.151],
     :type :vor/dme,
-    :pronunciation "bridgeport"}
+    :name "bridgeport"}
    {:id "BELTT",
     :position [:N41*03'48.610 :W072*59'13.520],
-    :type :fix}
+    :type :fix,
+    :pronunciation "belt"}
    {:id "BETTE",
     :position [:N40*33'33.260 :W073*00'42.210],
     :type :fix}
    {:id "BOTON",
     :position [:N39*24'52.100 :W074*27'17.080],
-    :type :fix}
+    :type :fix,
+    :pronunciation "bo ton"}
    {:id "CAMRN",
     :position [:N40*01'02.290 :W073*51'39.810],
-    :type :fix}
+    :type :fix,
+    :pronunciation "cameron"}
    {:id "CANDR",
     :position [:N40*58'15.550 :W074*57'35.380],
-    :type :fix}
+    :type :fix,
+    :pronunciation "candor"}
    {:id "CAPIT",
     :position [:N40*45'37.990 :W073*37'49.460],
-    :type :fix}
+    :type :fix,
+    :pronunciation "ca pit"}
    {:id "CCC",
     :position [:N40*55'46.628 :W072*47'55.890],
     :type :vor/dme,
-    :pronunciation "calverton"}
+    :name "calverton"}
    {:id "COATE",
     :position [:N41*08'10.420 :W074*41'42.600],
-    :type :fix}
+    :type :fix,
+    :pronunciation "coat"}
    {:id "CODDI",
     :position [:N42*22'52.150 :W075*00'21.840],
-    :type :fix}
+    :type :fix,
+    :pronunciation "codi"}
    {:id "DEEDE",
     :position [:N41*38'47.810 :W073*32'25.740],
-    :type :fix}
+    :type :fix,
+    :pronunciation "deedee"}
    {:id "DEEZZ",
     :position [:N41*06'52.000 :W073*46'40.000],
-    :type :fix}
+    :type :fix,
+    :pronunciation "de ezz"}
    {:id "DENNA",
-    :position [:N41*13'59.780 :W073*11'37.930],
-    :type :fix}
+    :position [:N41*13'59.790 :W073*11'37.940],
+    :type :fix,
+    :pronunciation "dena"}
    {:id "DIXIE",
     :position [:N40*05'57.720 :W074*09'52.170],
     :type :fix}
    {:id "DNY",
     :position [:N42*10'41.810 :W074*57'24.986],
     :type :vor/dme,
-    :pronunciation "delancey"}
+    :name "delancey"}
    {:id "DOORE",
     :position [:N41*01'41.440 :W074*22'03.730],
-    :type :fix}
+    :type :fix,
+    :pronunciation "door"}
    {:id "DPK",
     :position [:N40*47'30.299 :W073*18'13.168],
     :type :vor/dme,
-    :pronunciation "deer park"}
+    :name "deer park"}
    {:id "ENE",
     :position [:N43*25'32.420 :W070*36'48.692],
     :type :vor/dme,
-    :pronunciation "kennebunk"}
+    :name "kennebunk"}
    {:id "FZOOL",
     :position [:N41*19'35.110 :W073*16'59.580],
     :type :fix}
    {:id "GAMBY",
     :position [:N40*00'22.220 :W073*52'08.270],
-    :type :fix}
+    :type :fix,
+    :pronunciation "gam bee"}
    {:id "GAYEL",
     :position [:N41*24'24.090 :W074*21'25.720],
-    :type :fix}
+    :type :fix,
+    :pronunciation "gayle"}
    {:id "GREKI",
     :position [:N41*28'48.030 :W073*18'50.980],
-    :type :fix}
+    :type :fix,
+    :pronunciation "gre ki"}
    {:id "GROUP",
     :position [:N42*33'50.100 :W073*48'23.330],
     :type :fix}
    {:id "HAAYS",
     :position [:N41*19'12.020 :W074*28'01.850],
-    :type :fix}
+    :type :fix,
+    :pronunciation "hays"}
    {:id "HARTY",
     :position [:N41*04'16.280 :W075*05'23.620],
     :type :fix}
    {:id "HOGGS",
     :position [:N39*34'58.250 :W074*16'14.070],
-    :type :fix}
+    :type :fix,
+    :pronunciation "hogs"}
    {:id "IGN",
     :position [:N41*39'55.619 :W073*49'20.008],
     :type :vor/dme,
-    :pronunciation "kingston"}
+    :name "kingston"}
    {:id "JENNO",
     :position [:N41*09'10.530 :W075*19'53.070],
-    :type :fix}
+    :type :fix,
+    :pronunciation "jeno"}
    {:id "JFK",
     :position [:N40*37'58.400 :W073*46'17.000],
     :type :vor/dme,
-    :pronunciation "kennedy"}
+    :name "kennedy"}
    {:id "KARRS",
     :position [:N39*50'27.140 :W073*59'09.560],
-    :type :fix}
+    :type :fix,
+    :pronunciation "kars"}
    {:id "LENDY",
     :position [:N40*54'53.410 :W074*08'06.930],
-    :type :fix}
+    :type :fix,
+    :pronunciation "len dee"}
    {:id "LGA",
     :position [:N40*47'01.376 :W073*52'06.962],
     :type :vor/dme,
-    :pronunciation "la guardia"}
+    :name "la guardia"}
    {:id "LOLLY",
     :position [:N41*23'07.810 :W074*03'48.540],
     :type :fix}
@@ -159,19 +181,22 @@
    {:id "LVZ",
     :position [:N41*16'22.076 :W075*41'22.078],
     :type :vortac,
-    :pronunciation "wilkes barre"}
+    :name "wilkes barre"}
    {:id "MERIT",
     :position [:N41*22'55.020 :W073*08'14.750],
     :type :fix}
    {:id "NEION",
     :position [:N41*13'41.210 :W074*34'50.780],
-    :type :fix}
+    :type :fix,
+    :pronunciation "ne ion"}
    {:id "NESSI",
     :position [:N41*06'01.600 :W073*02'21.280],
-    :type :fix}
+    :type :fix,
+    :pronunciation "ne ssi"}
    {:id "PANZE",
     :position [:N39*40'33.580 :W074*10'05.450],
-    :type :fix}
+    :type :fix,
+    :pronunciation "pan ze"}
    {:id "PARCH",
     :position [:N41*05'57.220 :W072*07'14.660],
     :type :fix}
@@ -181,19 +206,20 @@
    {:id "PVD",
     :position [:N41*43'27.633 :W071*25'46.708],
     :type :vor/dme,
-    :pronunciation "providence"}
+    :name "providence"}
    {:id "PWL",
     :position [:N41*46'11.177 :W073*36'01.985],
     :type :vor/dme,
-    :pronunciation "pawling"}
+    :name "pawling"}
    {:id "RBV",
     :position [:N40*12'08.648 :W074*29'42.094],
     :type :vortac,
-    :pronunciation "robbinsville"}
+    :name "robbinsville",
+    :pronunciation "robbins fill"}
    {:id "RKA",
     :position [:N42*27'58.790 :W075*14'21.221],
     :type :vor/dme,
-    :pronunciation "rockdale"}
+    :name "rockdale"}
    {:id "RNGRR",
     :position [:N40*13'48.590 :W074*12'20.690],
     :type :fix}
@@ -203,27 +229,29 @@
    {:id "SEY",
     :position [:N41*10'02.770 :W071*34'33.910],
     :type :vor/dme,
-    :pronunciation "sandy point"}
+    :name "sandy point"}
    {:id "SHIPP",
     :position [:N40*19'45.960 :W073*14'50.180],
     :type :fix}
    {:id "SIE",
     :position [:N39*05'43.832 :W074*48'01.238],
     :type :vortac,
-    :pronunciation "sea isle"}
+    :name "sea isle"}
    {:id "STW",
     :position [:N40*59'44.951 :W074*52'08.509],
     :type :vor/dme,
-    :pronunciation "stillwater"}
+    :name "stillwater"}
    {:id "TOWIN",
     :position [:N40*32'06.760 :W075*24'01.360],
-    :type :fix}
+    :type :fix,
+    :pronunciation "to win"}
    {:id "TRAIT",
     :position [:N41*17'04.750 :W071*55'03.350],
     :type :fix}
    {:id "WAVEY",
     :position [:N40*14'04.500 :W073*23'39.760],
-    :type :fix}
+    :type :fix,
+    :pronunciation "wa vey"}
    {:id "WHITE",
     :position [:N40*00'24.320 :W074*15'04.610],
     :type :fix}]})

--- a/src/main/atc/data/airports/kjfk.cljc
+++ b/src/main/atc/data/airports/kjfk.cljc
@@ -26,7 +26,7 @@
   [{:id "ACOVE",
     :position [:N42*14'05.220 :W074*01'54.590],
     :type :fix,
-    :pronunciation "ac ove"}
+    :pronunciation "a cove"}
    {:id "AGNEZ",
     :position [:N42*13'32.710 :W074*11'18.750],
     :type :fix,
@@ -67,7 +67,7 @@
    {:id "CAMRN",
     :position [:N40*01'02.290 :W073*51'39.810],
     :type :fix,
-    :pronunciation "cameron"}
+    :pronunciation "cam rn"}
    {:id "CANDR",
     :position [:N40*58'15.550 :W074*57'35.380],
     :type :fix,
@@ -118,10 +118,12 @@
    {:id "ENE",
     :position [:N43*25'32.420 :W070*36'48.692],
     :type :vor/dme,
-    :name "kennebunk"}
+    :name "kennebunk",
+    :pronunciation "kenney bunk"}
    {:id "FZOOL",
     :position [:N41*19'35.110 :W073*16'59.580],
-    :type :fix}
+    :type :fix,
+    :pronunciation "fah zoo el"}
    {:id "GAMBY",
     :position [:N40*00'22.220 :W073*52'08.270],
     :type :fix,
@@ -222,7 +224,8 @@
     :name "rockdale"}
    {:id "RNGRR",
     :position [:N40*13'48.590 :W074*12'20.690],
-    :type :fix}
+    :type :fix,
+    :pronunciation "ranger"}
    {:id "ROBER",
     :position [:N40*41'07.670 :W073*01'57.400],
     :type :fix}
@@ -251,7 +254,7 @@
    {:id "WAVEY",
     :position [:N40*14'04.500 :W073*23'39.760],
     :type :fix,
-    :pronunciation "wa vey"}
+    :pronunciation "wave ee"}
    {:id "WHITE",
     :position [:N40*00'24.320 :W074*15'04.610],
     :type :fix}]})

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -56,7 +56,6 @@
 
           (map? item)
           (or
-            (:pronunciation item)
             (:radio-name item)
             (:name item)
             (:id item)

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -58,6 +58,7 @@
           (or
             (:radio-name item)
             (:name item)
+            (:pronunciation item)
             (:id item)
 
             (println "WARNING: " item "cannot be spoken"))

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -58,6 +58,7 @@
           (or
             (:pronunciation item)
             (:radio-name item)
+            (:name item)
             (:id item)
 
             (println "WARNING: " item "cannot be spoken"))

--- a/src/main/atc/voice/parsing/airport.cljc
+++ b/src/main/atc/voice/parsing/airport.cljc
@@ -5,9 +5,11 @@
 
 (defn generate-parsing-context [airport]
   (let [navaids-by-pronunciation (reduce
-                                   (fn [m {:keys [pronunciation id]}]
+                                   (fn [m {:keys [pronunciation name id]}]
                                      (assoc m
                                             (or pronunciation
+                                                (when name
+                                                  (str/lower-case name))
                                                 (str/lower-case id))
                                             id))
                                    {}

--- a/src/main/atc/voice/recognizer.cljs
+++ b/src/main/atc/voice/recognizer.cljs
@@ -55,6 +55,9 @@
                grammar-content (when grammar
                                  (println "Generating grammar..." grammar)
                                  (time (grammar/generate grammar)))
+
+               _ (println "Prepared grammar: " grammar-content)
+
                recognizer (if (some? grammar-content)
                             (new KaldiRecognizer sample-rate grammar-content)
                             (new KaldiRecognizer sample-rate))]

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -128,7 +128,10 @@
 
       (check-dedup-letter-pairs word)
 
-      (check-swap-latters word))))
+      (check-swap-latters word)
+
+      ; As a last-ditch, try splitting small words, too
+      (check-split-words word))))
 
 (comment
   (time (missing-words "deer park"))

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -89,7 +89,8 @@
    [#"([b-df-hj-np-tv-z])r" ["$1er"
                              "$1or"]]
    [#"([b-df-hj-np-tv-z])y" [" $1ee"
-                             "$1 ee"]]])
+                             "$1 ee"]]
+   [#"ey$" "e ee"]])
 
 (defn- check-swap-latters [word]
   (loop [swaps letter-swaps]

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -86,12 +86,20 @@
 (def ^:private letter-swaps
   [[#"z" "s"]
    [#"el" "le"]
+
+   ; EG: candr -> candor
    [#"([b-df-hj-np-tv-z])r" ["$1er"
                              "$1or"]]
+
+   ; EG: lendy -> len dee or lend ee
    [#"([b-df-hj-np-tv-z])y" [" $1ee"
                              "$1 ee"]]
-   [#"^a" "a "]
-   [#"ey$" "e ee"]])
+
+   ; EG: wavey -> wave ee
+   [#"ey$" "e ee"]
+
+   ; EG: acove -> "a cove"
+   [#"^a" "a "]])
 
 (defn- check-swap-latters [word]
   (loop [swaps letter-swaps]

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -35,6 +35,9 @@
   (when word
     (@dictionary-checker word)))
 
+(defn pronounceable? [word]
+  (nil? (missing-words word)))
+
 (defn unpronounceable [candidates]
   (->> candidates
        (pmap #(when-some [missing (missing-words %)]
@@ -65,7 +68,6 @@
 (defn make-pronounceable [word]
   (or (check-split-words word)
       word))
-
 
 (comment
   (time (missing-words "deer park"))

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -90,6 +90,7 @@
                              "$1or"]]
    [#"([b-df-hj-np-tv-z])y" [" $1ee"
                              "$1 ee"]]
+   [#"^a" "a "]
    [#"ey$" "e ee"]])
 
 (defn- check-swap-latters [word]

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -84,9 +84,12 @@
       dedup'd)))
 
 (def ^:private letter-swaps
-  [[#"el" "le"]
+  [[#"z" "s"]
+   [#"el" "le"]
    [#"([b-df-hj-np-tv-z])r" ["$1er"
-                             "$1or"]]])
+                             "$1or"]]
+   [#"([b-df-hj-np-tv-z])y" [" $1ee"
+                             "$1 ee"]]])
 
 (defn- check-swap-latters [word]
   (loop [swaps letter-swaps]

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -34,7 +34,7 @@
                  (keep
                    (fn [word]
                      ; NOTE: This is terribly hacky... but it works
-                     (when-not (re-find (re-pattern (str "\\b" word "(\\b|[0-9])")) data)
+                     (when-not (re-find (re-pattern (str "\\b" word "[^a-z]")) data)
                        word)))
                  seq)))))))
 

--- a/src/tool/atc/pronunciation.clj
+++ b/src/tool/atc/pronunciation.clj
@@ -60,14 +60,41 @@
   (->> (split-words word)
        (pmap (fn [pair]
                (let [new-word (str/join " " pair)]
-                 (when-not (missing-words new-word)
+                 (when (pronounceable? new-word)
                    new-word))))
        (keep identity)
        first))
 
+(defn- check-double-trailing-vowel [word]
+  (let [doubled (str word (last word))]
+    (when (pronounceable? doubled)
+      doubled)))
+
+(defn- check-strip-trailing-vowel [word]
+  (let [without (subs word 0 (dec (count word)))]
+    (when (pronounceable? without)
+      without)))
+
+(defn- dedup-consonants [word]
+  (let [dedup'd (str/replace word #"([b-df-hj-np-tv-z])\1" "$1")]
+    (when (pronounceable? dedup'd)
+      dedup'd)))
+
 (defn make-pronounceable [word]
-  (or (check-split-words word)
-      word))
+  (println "MAKE PRONOUNCEABLE" word)
+  (if (pronounceable? word)
+    word
+
+    (or (when (> (count word) 5)
+          (check-split-words word))
+
+        (when (str/ends-with? word "e")
+          (check-double-trailing-vowel word))
+
+        (when (str/ends-with? word "e")
+          (check-strip-trailing-vowel word))
+
+        (dedup-consonants word))))
 
 (comment
   (time (missing-words "deer park"))

--- a/src/tool/atc/pronunciation/manual.clj
+++ b/src/tool/atc/pronunciation/manual.clj
@@ -3,4 +3,6 @@
   cannot be easily derived from the input")
 
 (def manually-defined-pronunciations
-  {"camrn" "cameron"})
+  {"kennebunk" "kenney bunk"
+   "fzool" "fah zoo el"
+   "rngrr" "ranger"})

--- a/src/tool/atc/pronunciation/manual.clj
+++ b/src/tool/atc/pronunciation/manual.clj
@@ -1,0 +1,6 @@
+(ns atc.pronunciation.manual
+  "A collection of manually-defined navaid pronunciations that
+  cannot be easily derived from the input")
+
+(def manually-defined-pronunciations
+  {"camrn" "cameron"})

--- a/src/tool/atc/pronunciation/manual.clj
+++ b/src/tool/atc/pronunciation/manual.clj
@@ -4,5 +4,6 @@
 
 (def manually-defined-pronunciations
   {"kennebunk" "kenney bunk"
+   ; NOTE: Sometimes just "fah zoo" works better with TTS... Perhaps we can support alternates at some point...
    "fzool" "fah zoo el"
    "rngrr" "ranger"})

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -1,0 +1,8 @@
+(ns atc.pronunciation-test
+  (:require
+   [atc.pronunciation :refer [missing-words]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest missing-words-test
+  (testing "No false positives"
+    (is (nil? (missing-words "sea isle")))))

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -32,7 +32,18 @@
            (make-pronounceable
              "doore"))))
 
-  (testing "Dedup consonants"
+  (testing "Dedup letters"
     (is (= "kars"
            (make-pronounceable
-             "karrs")))))
+             "karrs")))
+    (is (= "hays"
+           (make-pronounceable
+             "haays"))))
+
+  (testing "Swap letters"
+    (is (= "gayle"
+           (make-pronounceable
+             "gayel")))
+    (is (= "candor"
+           (make-pronounceable
+             "candr")))))

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -1,8 +1,21 @@
 (ns atc.pronunciation-test
   (:require
-   [atc.pronunciation :refer [missing-words]]
+   [atc.pronunciation :refer [make-pronounceable missing-words]]
    [clojure.test :refer [deftest is testing]]))
 
 (deftest missing-words-test
   (testing "No false positives"
-    (is (nil? (missing-words "sea isle")))))
+    (is (nil? (missing-words "sea isle")))
+    (is (nil? (missing-words "rober")))))
+
+(deftest make-pronounceable-test
+  (testing "split words"
+    (is (= "robbins fill"
+           (make-pronounceable
+             "robbinsville"))))
+
+  (testing "don't split words too aggressively"
+    ; TODO
+    #_(is (= "parch"
+           (make-pronounceable
+             "parch")))))

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -46,4 +46,10 @@
              "gayel")))
     (is (= "candor"
            (make-pronounceable
-             "candr")))))
+             "candr")))
+    (is (= "gam bee"
+           (make-pronounceable
+             "gamby")))
+    (is (= "len dee"
+           (make-pronounceable
+             "lendy")))))

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -9,13 +9,30 @@
     (is (nil? (missing-words "rober")))))
 
 (deftest make-pronounceable-test
-  (testing "split words"
+  (testing "Split words"
     (is (= "robbins fill"
            (make-pronounceable
              "robbinsville"))))
 
-  (testing "don't split words too aggressively"
-    ; TODO
-    #_(is (= "parch"
+  (testing "Don't split words *too* aggressively"
+    (is (= "parch"
            (make-pronounceable
-             "parch")))))
+             "parch"))))
+
+  (testing "Add trailing `e`"
+    (is (= "deedee"
+           (make-pronounceable
+             "deede"))))
+
+  (testing "Strip trailing `e`"
+    (is (= "coat"
+           (make-pronounceable
+             "coate")))
+    (is (= "door"
+           (make-pronounceable
+             "doore"))))
+
+  (testing "Dedup consonants"
+    (is (= "kars"
+           (make-pronounceable
+             "karrs")))))

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -52,4 +52,8 @@
              "gamby")))
     (is (= "len dee"
            (make-pronounceable
-             "lendy")))))
+             "lendy")))
+
+    (is (= "wave ee"
+           (make-pronounceable
+             "wavey")))))

--- a/src/tool/atc/pronunciation_test.clj
+++ b/src/tool/atc/pronunciation_test.clj
@@ -54,6 +54,10 @@
            (make-pronounceable
              "lendy")))
 
+    (is (= "a cove"
+           (make-pronounceable
+             "acove")))
+
     (is (= "wave ee"
            (make-pronounceable
              "wavey")))))

--- a/src/tool/atc/tool.clj
+++ b/src/tool/atc/tool.clj
@@ -25,7 +25,8 @@
                    :position [(:latitude fix) (:longitude fix)]
                    :type (:type fix)}
              raw-pronunciation (or (:radio-voice-name fix)
-                                   (:name fix))
+                                   (:name fix)
+                                   (:id fix))
 
              cleaned-pronunciation (when raw-pronunciation
                                      (-> raw-pronunciation
@@ -42,7 +43,6 @@
            (assoc :name cleaned-pronunciation)
 
            (and (some? pronunciation)
-                (not= raw-pronunciation (:id fix))
                 (not= pronunciation cleaned-pronunciation))
            (assoc :pronunciation pronunciation))))
      items))

--- a/src/tool/atc/tool.clj
+++ b/src/tool/atc/tool.clj
@@ -113,12 +113,12 @@
     (pprint airport)
 
     (when-let [unpronounceable (time
-                                 (doall
-                                   (pronunciation/unpronounceable
-                                     (map #(or (:pronunciation %)
-                                               (:name %)
-                                               (:id %))
-                                          (:navaids airport)))))]
+                                 (->> (:navaids airport)
+                                      (map #(or (:pronunciation %)
+                                                (:name %)
+                                                (:id %)))
+                                      (pronunciation/unpronounceable)
+                                      seq))]
       (println "WARNING: Detected" (count unpronounceable) "unpronounceable navaids:")
       (println "\t" unpronounceable))
 

--- a/src/tool/atc/tool.clj
+++ b/src/tool/atc/tool.clj
@@ -116,6 +116,7 @@
                                  (doall
                                    (pronunciation/unpronounceable
                                      (map #(or (:pronunciation %)
+                                               (:name %)
                                                (:id %))
                                           (:navaids airport)))))]
       (println "WARNING: Detected" (count unpronounceable) "unpronounceable navaids:")

--- a/src/tool/atc/vosk/fst.clj
+++ b/src/tool/atc/vosk/fst.clj
@@ -1,0 +1,77 @@
+(ns atc.vosk.fst
+  (:require
+   [atc.okay :as okay :refer [compile-record]]))
+
+(def ^:private fst-file-name "model/graph/Gr.fst")
+(def ^:private flag-has-input-table 0x01)
+(def ^:private flag-has-output-table 0x02)
+(def ^:private supported-fst-version 4)
+
+(defn skip-to-fst-file [tar-stream]
+  (loop []
+    (if-let [next-entry (.getNextEntry tar-stream)]
+      (if (= fst-file-name (.getName next-entry))
+        next-entry
+        (recur))
+
+      (throw (ex-info "Could not find Gr.fst in model.tar.gz" {})))))
+
+(def string (okay/prefixed-string okay/integer-le))
+(def unsigned-int okay/integer-le)
+(def unsigned-long okay/long-integer-le)
+
+(def fst-header
+  (compile-record
+    [:magic-number okay/integer-le]
+    [:fst-type string]
+    [:arc-type string]
+    [:version unsigned-int]
+    [:flags unsigned-int]
+    [:properties unsigned-long]
+    [:start okay/long-integer-le]
+    [:numstates okay/long-integer-le]
+    [:numarcs okay/long-integer-le]))
+
+(def ^:private symbol-table-header
+  (compile-record
+    [:magic-number okay/integer-le]
+    [:name string]
+    [:available-key okay/long-integer-le]
+    [:size okay/long-integer-le]))
+
+(defn- read-symbol-table [in]
+  (let [header (okay/read-record symbol-table-header in)]
+    (->> (for [_ (range (:size header))]
+           (let [s (string in)]
+             ; This is the symbol key:
+             (okay/long-integer-le in)
+             s))
+         (into #{}))))
+
+(defn- read-fst [in]
+  (let [header (okay/read-record fst-header in)]
+    (when-not (= supported-fst-version (:version header))
+      (throw (ex-info (str "Unexpected FST header version: " (:version header))
+                      {:header header})))
+    {:header header
+     :input (when (not= 0 (bit-and (:flags header)
+                                   flag-has-input-table))
+              (read-symbol-table in))
+     :output (when (not= 0 (bit-and (:flags header)
+                                    flag-has-output-table))
+               (read-symbol-table in))}))
+
+(defn read-valid-words [in]
+  ; NOTE: For our purposes, input and output are identical...
+  (:input (read-fst (okay/buffered-source in))))
+
+(comment
+  #_:clj-kondo/ignore
+  (let [model-file (clojure.java.io/file "public/voice-model.tar.gz")]
+    (with-open [file-in (clojure.java.io/input-stream model-file)
+                gzip-stream (java.util.zip.GZIPInputStream. file-in)
+                tar-stream (org.apache.commons.compress.archivers.tar.TarArchiveInputStream. gzip-stream)]
+      (skip-to-fst-file tar-stream)
+      (count
+        (read-valid-words
+          (okay/buffered-source tar-stream))))))


### PR DESCRIPTION
Included is a bunch of somewhat manually-tuned heuristic techniques to transform un-pronounceable navaid names/IDs into something that a human can pronounce and the STT lib can understand. Vosk no longer complains that any words are not in its dictionary for KJFK navaids!

*Most* of the `:pronunciation` values were generated by these heuristics, but a handful are just too exotic to transform automatically, so the `atc.pronunciation.manual` may be used to manually describe a pronunciation in such cases. When's elected, the tool will still validate that the provided value is actually pronounceable from STT's perspective. 

As part of this change, we're making a clear distinction between `:name` and `:pronunciation`—the former, if available, is what TTS software should *always* use; the latter is what STT software should always prefer for understanding humans. Previously, we did not make a distinction, and always put the pronounceable thing in `:pronunciation`. Making this distinction should be beneficial moving forward—especially for navaids like `RBV` which TTS can pronounce nicely as "robbinsville" (`:name`) but STT needs a bit more hand-holding to comprehend: "robbins fill" (`:pronunciation`).

One of the driving forces behind these changes is that we finally *properly* read the FST from the packed language model in order to *precisely* get its table of known words. Doing so is actually *much* faster than our old technique of scanning the file for a matching string; I didn't measure it, but it's a set lookup vs a string scan with regex so it's a pretty obvious win. Once again, our `okay` library makes it real easy to read this structured file in, quickly.

- Improve word-pronounceability check somewhat
- Definitively fix pronunceability check by reading the FST table
- Output fixed pronunciation; distinguish from radio :name for TTS
- Fix pronounceability report
- Add some rough attempts to manipulate words into being pronounceable
- Add some more hand-tuned pronunciation tweaks
- Add some more letter swap rules
- Add one more letter swap proposal
- Try splitting small words as a last-ditch effort
- Try to treat words starting with "a" as if "a" were a separate word
- Clean up letter swaps with explanations
- Clean up pronounceability check output, fix final issues manually
- Also check :name as a way to pronounce a navaid
- Don't let STT try to use the :pronunciation key; that's for humans
- Add a small note as possible improvement
