### PR TITLE
Add basic support for departing aircraft behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out
 .cpcache/
 node_modules
 public/js
+nasr-data

--- a/src/main/atc/config.cljs
+++ b/src/main/atc/config.cljs
@@ -1,3 +1,6 @@
 (ns atc.config)
 
 (goog-define server-root "")
+
+; Aircraft may not exceed 250kts below 10K ft
+(def speed-limit-under-10k-kts 250)

--- a/src/main/atc/data/aircraft_configs.cljs
+++ b/src/main/atc/data/aircraft_configs.cljs
@@ -10,4 +10,10 @@
                    :turn-rate 3
 
                    :climb-rate 3000
-                   :descent-rate 3500}))
+                   :descent-rate 3500
+                   :acceleration 7
+                   :deceleration 3
+
+                   :min-speed 110
+                   :cruise-speed 460
+                   :landing-speed 125}))

--- a/src/main/atc/data/airlines.cljc
+++ b/src/main/atc/data/airlines.cljc
@@ -1,0 +1,15 @@
+(ns atc.data.airlines)
+
+(def all-airlines
+  {"AAL" {:callsign "AAL"
+          :radio-name "american"}
+   "BAW" {:callsign "BAW"
+          :radio-name "speed bird"}
+   "DAL" {:callsign "DAL"
+          :radio-name "delta"}
+   "JBU" {:callsign "JBU"
+          :radio-name "jet blue"}
+   "RPA" {:callsign "RPA"
+          :radio-name "brickyard"}
+   "SWA" {:callsign "SWA"
+          :radio-name "south west"}})

--- a/src/main/atc/data/airports.cljc
+++ b/src/main/atc/data/airports.cljc
@@ -3,6 +3,7 @@
    [atc.data.core :refer [local-xy]]
    [atc.data.units :refer [ft->m]]
    [atc.engine.model :refer [vec3]]
+   [atc.util.numbers :refer [->int]]
    [clojure.string :as str]
    [promesa.core :as p]
    [shadow.lazy :as lazy]))
@@ -49,3 +50,8 @@
       (if (= (:start-id runway-object) runway)
         [start end]
         [end start]))))
+
+(defn runway->heading [airport runway]
+  (-> (->int runway)
+      (* 10)
+      (- (:magnetic-north airport))))

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -68,6 +68,5 @@
                     :pilot (pilot/generate nil) ; TODO Pass in a preferred voice?
                     :position (vec3 250 250 (ft->m 20000))
                     :heading 350
-                    :speed 200
-                    :commands {:heading 90}}
+                    :speed 200}
                    data)))

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -9,6 +9,7 @@
                                               IGameEngine pending-communication
                                               prepare-pending-communication Simulated spawn-aircraft tick]]
    [atc.radio :as radio]
+   [atc.util.maps :refer [rename-key]]
    [atc.voice.parsing.airport :as airport-parsing]
    [atc.voice.process :refer [build-machine]]))
 
@@ -87,7 +88,8 @@
                  radio
                  (select-keys opts [:destination :config])
                  (-> this :airport :departure-routes
-                     (get (:destination opts)))
+                     (get (:destination opts))
+                     (rename-key :fix :departure-fix))
                  (when runway
                    ; FIXME: This heading doesn't seem to *look* quite correct
                    (let [position (first (runway-coords (:airport this) runway))]

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -4,8 +4,9 @@
    [atc.data.aircraft-configs :as configs]
    [atc.engine.aircraft :as aircraft]
    [atc.engine.model :as engine-model :refer [consume-pending-communication
-                                              pending-communication
-                                              prepare-pending-communication Simulated tick]]
+                                              IGameEngine pending-communication
+                                              prepare-pending-communication Simulated spawn-aircraft tick]]
+   [atc.radio :as radio]
    [atc.voice.parsing.airport :as airport-parsing]
    [atc.voice.process :refer [build-machine]]))
 
@@ -68,7 +69,24 @@
         ; There is no ~~spoon~~such aircraft:
         (do
           (println "WARNING: No such aircraft: " callsign)
-          this)))))
+          this))))
+
+  IGameEngine
+  (spawn-aircraft [this {:keys [config] :as opts}]
+    (when (= :ga (:type opts))
+      (throw (ex-info "GA aircraft not yet supported" {:opts opts})))
+
+    ; TODO: Support arrivals
+    ; TODO: Set initial position/heading of departures from :runways
+    (let [{:keys [callsign] :as radio} (radio/format-airline-radio
+                                         (:airline opts)
+                                         (:flight-number opts))
+          data (merge
+                 radio
+                 (select-keys opts [:destination :config])
+                 (-> this :airport :departure-routes
+                     (get (:destination opts))))]
+      (update this :aircraft assoc callsign (aircraft/create config data)))))
 
 (defn engine-grammar [^Engine engine]
   (get-in engine [:parsing-machine :fsm :grammar]))
@@ -79,23 +97,19 @@
 
 (defn generate [airport]
   ; TODO: Probably, generate the parsing-machine elsewhere for better loading states
-  ; TODO: Arrivals
-  ; TODO: Set initial position/heading of departures from :runways
-  (let [aircraft [{:callsign "DAL22"
-                   :radio-name "delta twenty two"
+  (let [aircraft [{:type :airline
+                   :airline "DAL"
+                   :flight-number 22
                    :destination (-> airport :departure-routes ffirst)
-                   :route (-> airport :departure-routes first second :route)
-                   :departure-fix (-> airport :departure-routes first second :fix)
+                   :runway (-> airport :runways first :start-id)
                    :config configs/common-jet}]]
-    (-> {:aircraft (reduce
-                     (fn [m {:keys [callsign config] :as data}]
-                       (assoc m callsign
-                              (aircraft/create config data)))
-                     {}
-                     aircraft)
+    (reduce
+      spawn-aircraft
+      (map->Engine
+        {:aircraft {}
          :airport airport
          :parsing-machine (build-machine (airport-parsing/generate-parsing-context airport))
          :elapsed-s 0
          :events nil
-         :time-scale 1}
-        (map->Engine))))
+         :time-scale 1})
+      aircraft)))

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -16,6 +16,26 @@
   (prepare-pending-communication [this])
   (consume-pending-communication [this]))
 
+(defprotocol IGameEngine
+  (spawn-aircraft
+    [this opts]
+    ; TODO support GA craft
+    "opts is a map with:
+     :type :airline/:ga
+     :origin str        ; icao of origin airport
+     :destination str   ; icao of destination airport
+     :config map        ; see aircraft.configs
+     :runway str        ; an active runway ID
+
+     ; for airlines:
+     :airline airline-id
+     :flight-number int
+
+     ; for ga:
+     :plane-type str
+     :tail-number str
+     "))
+
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defprotocol Vector

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -25,7 +25,7 @@
      :origin str        ; icao of origin airport
      :destination str   ; icao of destination airport
      :config map        ; see aircraft.configs
-     :runway str        ; an active runway ID
+     :runway str        ; an active runway ID, to start on ground
 
      ; for airlines:
      :airline airline-id

--- a/src/main/atc/radio_test.cljs
+++ b/src/main/atc/radio_test.cljs
@@ -1,6 +1,6 @@
 (ns atc.radio-test
   (:require
-   [atc.radio :refer [->readable ->speakable]]
+   [atc.radio :refer [->readable ->speakable format-airline-radio]]
    [cljs.test :refer-macros [deftest is testing]]))
 
 (deftest speakable-test
@@ -20,3 +20,17 @@
            (->readable [[{:id "DAL22"}
                          "cleared approach runway"
                          [:runway "13L"]]])))))
+
+(deftest format-airline-radio-test
+  (testing "Support four-digit flight-numbers"
+    (is (= {:callsign "DAL4297"
+            :radio-name "delta 42 97"}
+           (format-airline-radio "DAL" 4297))))
+  (testing "Support three-digit flight-numbers"
+    (is (= {:callsign "DAL942"
+            :radio-name "delta niner 42"}
+           (format-airline-radio "DAL" 942))))
+  (testing "Support two-digit flight-numbers"
+    (is (= {:callsign "DAL22"
+            :radio-name "delta 22"}
+           (format-airline-radio "DAL" 22)))))

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -2,6 +2,7 @@
   (:require
    [atc.data.core :refer [local-xy]]
    [atc.structures.rolling-history :refer [most-recent-n]]
+   [atc.util.numbers :refer [->int]]
    [clojure.string :as str]
    [re-frame.core :refer [reg-sub]]))
 
@@ -136,7 +137,7 @@
            (into #{})))))
 
 (defn- rwy-id->angle [airport id]
-  (-> (js/parseInt id 10)
+  (-> (->int id)
       (* 10)
       (- (:magnetic-north airport))))
 

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -1,8 +1,8 @@
 (ns atc.subs
   (:require
+   [atc.data.airports :refer [runway->heading]]
    [atc.data.core :refer [local-xy]]
    [atc.structures.rolling-history :refer [most-recent-n]]
-   [atc.util.numbers :refer [->int]]
    [clojure.string :as str]
    [re-frame.core :refer [reg-sub]]))
 
@@ -136,11 +136,6 @@
            (mapcat (juxt :start-id :end-id))
            (into #{})))))
 
-(defn- rwy-id->angle [airport id]
-  (-> (->int id)
-      (* 10)
-      (- (:magnetic-north airport))))
-
 (reg-sub
   :game/runways
   :<- [:game/airport]
@@ -150,8 +145,8 @@
          (map (fn [rwy]
                 (-> rwy
                     (assoc :position {:x 0 :y 0})
-                    (assoc :start-angle (rwy-id->angle airport (:start-id rwy)))
-                    (assoc :end-angle (rwy-id->angle airport (:end-id rwy)))
+                    (assoc :start-angle (runway->heading airport (:start-id rwy)))
+                    (assoc :end-angle (runway->heading airport (:end-id rwy)))
                     (update :start-threshold local-xy airport)
                     (update :end-threshold local-xy airport)))))))
 

--- a/src/main/atc/util/maps.cljc
+++ b/src/main/atc/util/maps.cljc
@@ -1,0 +1,6 @@
+(ns atc.util.maps)
+
+(defn rename-key [m k k']
+  (-> m
+      (dissoc k)
+      (assoc k' (get m k))))

--- a/src/main/atc/util/numbers.cljc
+++ b/src/main/atc/util/numbers.cljc
@@ -1,0 +1,5 @@
+(ns atc.util.numbers)
+
+(defn ->int [^String v]
+  #? (:cljs (js/parseInt v 10)
+      :clj (Integer/parseInt v)))

--- a/src/main/atc/util/numbers.cljs
+++ b/src/main/atc/util/numbers.cljs
@@ -1,0 +1,4 @@
+(ns atc.util.numbers)
+
+(defn ->int [^String v]
+  (js/parseInt v 10))

--- a/src/main/atc/util/numbers.cljs
+++ b/src/main/atc/util/numbers.cljs
@@ -1,4 +1,0 @@
-(ns atc.util.numbers)
-
-(defn ->int [^String v]
-  (js/parseInt v 10))

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -61,7 +61,7 @@
   (case mode
     :altitude/speed
     (let [alt-hundreds-ft (format-altitude (:z position))
-          speed-tens-kts (/ speed 10)]
+          speed-tens-kts (js/Math.floor (/ speed 10))]
       [alt-hundreds-ft speed-tens-kts])
 
     :exit-fix/aircraft-type

--- a/src/main/atc/voice/parsing/callsigns.cljc
+++ b/src/main/atc/voice/parsing/callsigns.cljc
@@ -1,10 +1,13 @@
-(ns atc.voice.parsing.callsigns 
+(ns atc.voice.parsing.callsigns
   (:require
+   [atc.data.airlines :refer [all-airlines]]
    [atc.voice.parsing.core :refer [declare-alternates]]))
 
 (def airlines
-  {"delta" "DAL"
-   "speed bird" "BAW"})
+  (->> all-airlines
+       (map (fn [[id {:keys [radio-name]}]]
+              [radio-name id]))
+       (into {})))
 
 (def plane-types
   ["piper"])

--- a/src/main/atc/voice/parsing/numbers.cljc
+++ b/src/main/atc/voice/parsing/numbers.cljc
@@ -2,15 +2,17 @@
   (:require
    [atc.voice.parsing.core :refer [declare-alternates]]))
 
+; NOTE: The "correct" radio phonology should come later in the map
+; so it's used instead of the "plain" word when we do map-invert
 (def digit-values
   {"zero" 0
    "one" 1
    "two" 2
-   "tree" 3
    "three" 3
+   "tree" 3
    "four" 4
-   "fife" 5
    "five" 5
+   "fife" 5
    "six" 6
    "seven" 7
    "eight" 8
@@ -36,7 +38,7 @@
    "sixty" 60
    "seventy" 70
    "eighty" 80
-   "ninety" 90 })
+   "ninety" 90})
 
 (def rules
   ["frequency = number-sequence? decimal number-sequence"
@@ -53,8 +55,7 @@
    "double-digit = (tens-value digit) | teens-value"
    (declare-alternates "digit" (keys digit-values))
    (declare-alternates "tens-value" (keys tens-values))
-   (declare-alternates "teens-value" (keys teens-values))
-   ])
+   (declare-alternates "teens-value" (keys teens-values))])
 
 (defn digits->number [digits]
   (loop [numbers (reverse digits)


### PR DESCRIPTION
Includes:

- Basic tooling for filling in aircraft data based on destination
- Support :runway in `spawn-aircraft` to start on the ground
- Support :target-speed aircraft command

Per commit notes:

```
    ... the next steps will be to 1. start the aircraft on the TWR
    frequency and call in on takeoff, and 2. add the frequencies for the
    adjacent airspace controllers and support handing off to them (but not
    necessarily in that order)
```