### PR TITLE
Add ITraffic protocol for generating traffic + RandomTraffic impl

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -15,6 +15,8 @@
                 ; input processing
                 [instaparse "1.4.12"]
                 [re-pressed "0.3.2"]
+                [metosin/spec-tools "0.10.5"]
+                [org.clojure/core.match "1.0.1"]
 
                 ; util:
                 [applied-science/js-interop "0.2.7"]
@@ -22,6 +24,7 @@
                 [funcool/promesa "11.0.671"]
                 [re-frame-utils "0.1.0"]
                 [com.rpl/specter "1.1.4"]
+                [org.clojure/test.check "1.1.1"]
 
                 ; dev tools:
                 [cider/cider-nrepl "0.24.0"]

--- a/src/main/atc/game.cljs
+++ b/src/main/atc/game.cljs
@@ -4,17 +4,48 @@
    [atc.data.airports :as airports]
    [atc.data.core :refer [local-xy]]
    [atc.engine.core :as engine]
-   [promesa.core :as p]))
+   [atc.game.traffic.factory :refer [create-traffic]]
+   [atc.util.spec :as spec]
+   [clojure.spec.alpha :as s]
+   [promesa.core :as p]
+   [spec-tools.data-spec :as ds]))
+
+(def ^:private game-options-defaults {:traffic :random})
+
+(def ^:private traffic-spec
+  (ds/or {:random (ds/or {:with-seed {(ds/opt :seed) number?}
+                          :default-seed (s/spec #{:random})})}))
+
+(def ^:private game-options-spec
+  (ds/spec
+    {:name ::game-options
+     :spec {:airport-id keyword?
+            (ds/opt :voice-input?) boolean?
+            (ds/opt :traffic) traffic-spec}}))
+
+(defn- expand-opts [opts]
+  (s/conform game-options-spec
+             (merge game-options-defaults opts)))
 
 (defn init-async [{:keys [airport-id] :as opts}]
-  {:pre [(keyword? airport-id)]}
-  (println "(re) Initialize game engine @ " opts)
-  (p/let [start (js/Date.now)
-          airport (airports/load-airport airport-id)
-          _ (println "Loaded " airport-id "in " (- (js/Date.now) start) "ms")
-          new-engine (engine/generate airport)]
-    (println "AC" (-> new-engine :aircraft vals first :position))
-    (let [lga (-> new-engine :airport :navaids (nth 2))]
-      (println (:id lga) (local-xy (-> lga :position)
-                                   (-> new-engine :airport))))
-    (>evt [:game/init-loaded-engine (assoc opts :engine new-engine)])))
+  {:pre [(spec/pre-validate game-options-spec opts)]}
+  (-> (p/let [opts (expand-opts opts)
+              _ (println "(re) Initialize game engine @ " opts)
+
+              start (js/Date.now)
+              airport (airports/load-airport airport-id)
+              _ (println "Loaded " airport-id "in " (- (js/Date.now) start) "ms")
+              traffic (create-traffic
+                        (:traffic opts))
+
+              new-engine (engine/generate {:airport airport
+                                           :traffic traffic})]
+        (println "AC" (-> new-engine :aircraft vals first :position))
+        (let [lga (-> new-engine :airport :navaids (nth 2))]
+          (println (:id lga) (local-xy (-> lga :position)
+                                       (-> new-engine :airport))))
+        (>evt [:game/init-loaded-engine (assoc opts :engine new-engine)]))
+
+      (p/catch (fn [e]
+                 ; TODO Notify UI somehow
+                 (js/console.error "ERROR initializing game engine: " e)))))

--- a/src/main/atc/game/traffic/factory.cljs
+++ b/src/main/atc/game/traffic/factory.cljs
@@ -1,0 +1,20 @@
+(ns atc.game.traffic.factory
+  (:require
+   [atc.game.traffic.model :refer [->ValidatedTraffic]]
+   [atc.game.traffic.random :refer [->RandomTraffic]]
+   [atc.util.seedable :refer [create-random]]
+   [clojure.core.match :refer [match]]))
+
+(defn create-traffic [spec]
+  (cond->
+    (match spec
+      [:random [:default-seed _]]
+      (->RandomTraffic
+        (create-random))
+
+      [:random [:with-seed {:seed seed}]]
+      (->RandomTraffic
+        (create-random seed)))
+
+    ; Wrap with a validator in debug mode
+    goog.DEBUG (->ValidatedTraffic)))

--- a/src/main/atc/game/traffic/model.cljs
+++ b/src/main/atc/game/traffic/model.cljs
@@ -1,0 +1,28 @@
+(ns atc.game.traffic.model
+  (:require
+   [clojure.spec.alpha :as s]
+   [spec-tools.data-spec :as ds]))
+
+(def flight-spec
+  (ds/spec
+    {:name ::flight
+     :spec {:aircraft {:type (s/spec #{:airline})
+                       :airline string?
+                       :flight-number number?
+                       :destination string? ; eg KJFK
+                       :runway string? ; eg 13L
+                       :config map?} ; from aircraft-configs
+            :delay-to-next-s number?}}))
+
+(defprotocol ITraffic
+  (next-departure [this engine]))
+
+(defrecord ValidatedTraffic [base]
+  ITraffic
+  (next-departure [_this engine]
+    (let [v (next-departure base engine)]
+      (when-not (s/valid? flight-spec v)
+        (throw (ex-info (str "Generated invalid traffic: "
+                             (s/explain flight-spec v))
+                        {:generated v})))
+      v)))

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -1,0 +1,21 @@
+(ns atc.game.traffic.random
+  (:require
+   [atc.data.aircraft-configs :as configs]
+   [atc.data.airlines :refer [all-airlines]]
+   [atc.game.traffic.model :refer [ITraffic]]
+   [atc.util.seedable :refer [next-int pick-random]]))
+
+(defrecord RandomTraffic [random]
+  ITraffic
+  (next-departure [_ {:keys [airport]}]
+    {:aircraft {:type :airline
+                :airline (pick-random random (keys all-airlines))
+                :flight-number (next-int random 20 9999)
+                :destination (pick-random
+                               random
+                               (-> airport :departure-routes keys))
+
+                ; TODO weather; runway selection
+                :runway (-> airport :runways first :start-id)
+                :config configs/common-jet}
+     :delay-to-next-s 100}))

--- a/src/main/atc/util/seedable.cljc
+++ b/src/main/atc/util/seedable.cljc
@@ -1,0 +1,37 @@
+(ns atc.util.seedable
+  (:require
+   [clojure.math :refer [floor]]
+   [clojure.test.check.random :as random :refer [make-random]]))
+
+(defprotocol IStatefulRandom
+  (next-double [this])
+  (next-int [this low high])
+  (pick-random [this values]))
+
+(defrecord StatefulRandom [state]
+  IStatefulRandom
+  (next-double [_]
+    (random/rand-double
+      (::returned
+        (swap! state (fn [{:keys [state]}]
+                       (let [[state' returned] (random/split state)]
+                         {:state state'
+                          ::returned returned}))))))
+
+  (next-int [this low high]
+    (let [v (next-double this)]
+      (+ low (floor (* (- high low)
+                       v)))))
+
+  (pick-random [this values]
+    (let [idx (next-int this 0 (count values))]
+      (nth
+        (if (vector? values)
+          values
+          (seq values))
+        idx))))
+
+(defn create-random
+  ([] (create-random #?(:cljs (js/Date.now)
+                        :clj (System/currentTimeMiillis))))
+  ([seed] (->StatefulRandom (atom {:state (make-random seed)}))))

--- a/src/main/atc/util/spec.cljc
+++ b/src/main/atc/util/spec.cljc
@@ -1,0 +1,13 @@
+(ns atc.util.spec
+  (:require [clojure.spec.alpha :as s]))
+
+(defn pre-validate
+  "Throw an exception if db doesn't have a valid spec."
+  [spec value]
+  (if (s/valid? spec value)
+    true
+    (do
+      (tap> value)
+      (let [explanation (s/explain-str spec value)]
+        (println "Spec check failed: " explanation)
+        false))))


### PR DESCRIPTION
RandomTraffic generates purely random traffic, without regard for time,
airport, anything. Just all RNG. In the future, we could support
weighted random traffic, so airports can declare the "types" of traffic
they typically experience (for added realism) or even potentially
"traffic files" or something, so you could potentially use real world
traffic (schedules)

This commit uses the seedable random functions from the test.check
library to generate repeatable traffic, based on a seed value. We don't
expose the seed anywhere yet, but we *could* for debug purposes---we can
probably render something in the post-game summary card, to give us a
way to recreate the game.

We don't yet use `ITraffic` to generate infinite departures; that'll come next!