### PR TITLE
Support generating infinite departing aircraft

### DIFF
--- a/src/main/atc/engine/queues.cljs
+++ b/src/main/atc/engine/queues.cljs
@@ -1,0 +1,37 @@
+(ns atc.engine.queues
+  (:require
+   [atc.engine.model :refer [spawn-aircraft]]
+   [atc.game.traffic.model :refer [next-departure]]))
+
+(def ^:private queues
+  {:departure (fn departure-queue [{engine :engine
+                                    {:keys [next-time-s]} :state}]
+                (loop [engine engine
+                       next-time-s next-time-s]
+                  (if (> next-time-s
+                         (:elapsed-s engine))
+                    ; Nothing more to do!
+                    {:engine engine
+                     :state {:next-time-s next-time-s}}
+
+                    ; Spawn another departure
+                    (let [{:keys [aircraft delay-to-next-s]}
+                          (next-departure (:traffic engine) engine)]
+                      (recur (spawn-aircraft engine aircraft)
+                             (+ next-time-s delay-to-next-s))))))})
+
+(defn run-queues [engine]
+  (reduce-kv
+    (fn [engine' queue-key queue-fn]
+      (let [result (queue-fn {:engine engine'
+                              :state (get-in engine' [:queues queue-key])})]
+        (assoc-in (:engine result) [:queues queue-key] (:state result))))
+    engine
+    queues))
+
+#_{:clj-kondo/ignore [:unresolved-namespace]}
+(comment
+
+  (vector
+    (get-in @re-frame.db/app-db [:engine :elapsed-s])
+    (get-in @re-frame.db/app-db [:engine :queues :departure])))

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -18,4 +18,6 @@
                 ; TODO weather; runway selection
                 :runway (-> airport :runways first :start-id)
                 :config configs/common-jet}
-     :delay-to-next-s 100}))
+
+     ; TODO This should at least depend on the spawned aircraft's speed, etc. Maybe "difficulty"?
+     :delay-to-next-s 240}))


### PR DESCRIPTION
This feature is powered by a new "queues" abstraction for handling
repetitive tasks.  A queue has some state, stored in the engine, which can
be checked on every tick trigger side effects on the engine, and return a
new state to be passed in on the next tick. Queues are processed *after*
aircraft simulation updates, at the very end of a tick.

The departures queue uses its state to track the "next time a departure
should occur," according to the Traffic in the engine. We could consider
keeping a separate Traffic instance for arrivals and departures, using the
"split" random feature of `test.check`, which would let us move the Traffic
object out of the engine itself and keep it in the queue state. That in turn could let us potentially refactor our randomness into a stateless/immutable model, so generating new traffic would give us a new Traffic instance, and any given instance will *always* provide the same traffic....
