### PR TITLE
Build the grammar parser at compile time

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -26,5 +26,8 @@
            gloss.core/defcodec clojure.core/def
            instaparse.core/defparser clojure.core/def
            reagent.core/with-let clojure.core/let
-           secretary.core/defroute clojure.core/fn}}
+           secretary.core/defroute clojure.core/fn
+
+           atc.util.instaparse/defalternates clojure.core/def
+           atc.util.instaparse/defrules clojure.core/def}}
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -29,5 +29,6 @@
            secretary.core/defroute clojure.core/fn
 
            atc.util.instaparse/defalternates clojure.core/def
+           atc.util.instaparse/defalternates-expr clojure.core/def
            atc.util.instaparse/defrules clojure.core/def}}
 

--- a/src/main/atc/data/airlines.cljc
+++ b/src/main/atc/data/airlines.cljc
@@ -1,8 +1,6 @@
-(ns atc.data.airlines
-  (:require
-   [atc.voice.parsing.callsigns :refer [airline-names]]))
+(ns atc.data.airlines)
 
-#_(def all-airlines
+(def all-airlines
   {"AAL" {:callsign "AAL"
           :radio-name "american"}
    "BAW" {:callsign "BAW"
@@ -15,10 +13,3 @@
           :radio-name "brickyard"}
    "SWA" {:callsign "SWA"
           :radio-name "south west"}})
-
-(def all-airlines
-  (->> airline-names
-       (into {}
-             (map (fn [[radio-name id]]
-                    [id {:callsign radio-name
-                         :radio-name radio-name}])))))

--- a/src/main/atc/data/airlines.cljc
+++ b/src/main/atc/data/airlines.cljc
@@ -1,6 +1,8 @@
-(ns atc.data.airlines)
+(ns atc.data.airlines
+  (:require
+   [atc.voice.parsing.callsigns :refer [airline-names]]))
 
-(def all-airlines
+#_(def all-airlines
   {"AAL" {:callsign "AAL"
           :radio-name "american"}
    "BAW" {:callsign "BAW"
@@ -13,3 +15,10 @@
           :radio-name "brickyard"}
    "SWA" {:callsign "SWA"
           :radio-name "south west"}})
+
+(def all-airlines
+  (->> airline-names
+       (into {}
+             (map (fn [[radio-name id]]
+                    [id {:callsign radio-name
+                         :radio-name radio-name}])))))

--- a/src/main/atc/data/airports.cljc
+++ b/src/main/atc/data/airports.cljc
@@ -12,7 +12,7 @@
 ; since they should be code-split
 #_{:clj-kondo/ignore [:unresolved-namespace]}
 (def ^:private airport-loadables
-  {:kjfk (lazy/loadable atc.data.airports.kjfk/airport)})
+  {:kjfk (lazy/loadable atc.data.airports.kjfk/exports)})
 
 (defn list-airports []
   (->> airport-loadables
@@ -24,15 +24,25 @@
 (defn load-airport [airport-id]
   (if-some [loadable (get airport-loadables airport-id)]
     (if (lazy/ready? loadable)
-      @loadable
+      (:airport @loadable)
       (-> ; NOTE: lazy/load *should* return a promise, but it
           ; does not seem to play well with promesa, so...
           (p/create
             (fn [p-resolve p-reject]
               (lazy/load loadable p-resolve p-reject)))
+          (p/then :airport)
           (p/catch #?(:clj (partial println "[ERROR]")
                       :cljs js/console.error))))
     (throw (ex-info "No such airport: " {:id airport-id}))))
+
+(defn airport-parsing-rules [airport-id]
+  (:navaid-pronounced
+    @(get airport-loadables airport-id)))
+
+(defn airport-parsing-transformers [airport-id]
+  {:navaid-pronounced
+   (:navaids-by-pronunciation
+     @(get airport-loadables airport-id))})
 
 (defn runway-coords [airport runway]
   (when-let [runway-object (->> airport

--- a/src/main/atc/data/airports/kjfk.cljc
+++ b/src/main/atc/data/airports/kjfk.cljc
@@ -1,4 +1,7 @@
-(ns atc.data.airports.kjfk)
+(ns atc.data.airports.kjfk
+ (:require
+  [atc.voice.parsing.airport :as parsing]
+  [atc.util.instaparse :refer-macros [defalternates-expr]]))
 
 (def airport
  {:magnetic-north -13.0,
@@ -571,3 +574,15 @@
   {:cd {:frequency "135.05", :track-symbol "D"},
    :twr {:frequency "119.1", :track-symbol "T"},
    :gnd {:frequency "121.9", :track-symbol "G"}}})
+
+
+(def navaids-by-pronunciation
+  (parsing/airport->navaids-by-pronunciation airport))
+
+(defalternates-expr navaid-pronounced
+  (keys navaids-by-pronunciation))
+
+(def exports
+ {:airport airport
+  :navaids-by-pronunciation navaids-by-pronunciation
+  :navaid-pronounced navaid-pronounced})

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -12,7 +12,6 @@
    [atc.engine.queues :refer [run-queues]]
    [atc.radio :as radio]
    [atc.util.maps :refer [rename-key]]
-   [atc.voice.parsing.airport :as airport-parsing]
    [atc.voice.process :refer [build-machine]]))
 
 (defn- dispatch-instructions [^Simulated simulated, context instructions]
@@ -141,7 +140,7 @@
      :tracked-aircraft {}
      :airport airport
      :traffic traffic
-     :parsing-machine (build-machine (airport-parsing/generate-parsing-context airport))
+     :parsing-machine (build-machine airport)
      :elapsed-s 0
      :events []
      :queues {}

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -134,7 +134,6 @@
     (* 250 (/ 1 (:time-scale engine)))))
 
 (defn generate [{:keys [airport traffic]}]
-  ; TODO: Probably, generate the parsing-machine elsewhere for better loading states
   (map->Engine
     {:aircraft {}
      :tracked-aircraft {}

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -46,10 +46,10 @@
   [[_ v]]
   (cond
     (<= 0 v 9)
-    (get (map-invert numbers/digit-values) v)
+    (get (map-invert numbers/digit) v)
 
     (<= 10 v 19)
-    (get (map-invert numbers/teens-values) v)
+    (get (map-invert numbers/teens-value) v)
 
     :else v))
 

--- a/src/main/atc/util/instaparse.cljc
+++ b/src/main/atc/util/instaparse.cljc
@@ -39,6 +39,18 @@
                   ~value
                   {:grammar ~(compile-grammar parseable-grammar)}))))
 
+(defmacro defalternates-expr [name expr]
+  (let [red (if (:hide-tag (meta name))
+              {:reduction-type :raw}
+              {:reduction-type :hiccup, :key :other-position})]
+    `(def ~name {:grammar
+                 {~(keyword (str name))
+                  {:tag :alt
+                   :red ~red
+                   :parsers (->> ~expr
+                                 (map (fn [v#]
+                                        {:tag :string, :string v#})))}}})))
+
 (defn- format-dependencies-map [dependencies-map]
   (->> dependencies-map
        (map (fn [[k v]]

--- a/src/main/atc/util/instaparse.cljc
+++ b/src/main/atc/util/instaparse.cljc
@@ -1,0 +1,73 @@
+(ns atc.util.instaparse
+  (:require
+   [atc.voice.parsing.core :refer [declare-alternates]]
+   [clojure.string :as str]
+   [clojure.walk :as walk]
+   [instaparse.core :as insta]))
+
+(defn compile-grammar [parseable-grammar]
+  (->> (insta/parser parseable-grammar)
+       (walk/postwalk
+         (fn [form]
+           (cond
+             ;; Lists cannot be evaluated verbatim
+             (seq? form)
+             (list* 'list form)
+
+             :else form)))
+       :grammar))
+
+(defn generate-grammar-nops [nop-names]
+  ; NOTE (name n) doesn't work in the defrules macro for some reason
+  (map (fn [n] (cond-> (str n " = 'nop'")
+                 (keyword? n) (subs 1)))
+       nop-names))
+
+(defmacro defalternates
+  "The name can be tagged with ^:hide-tag to hide the tag from the output.
+   This is equivalent to declaring the rule with <angle brackets> around the
+   tag name."
+  [name value]
+  (let [alternates (if (map? value)
+                     (keys value)
+                     value)
+        hide-tag (fn [s] (str "<" s ">"))
+        tag-name (cond-> (str name)
+                   (:hide-tag (meta name)) (hide-tag))
+        parseable-grammar (declare-alternates tag-name alternates)]
+    `(def ~name (with-meta
+                  ~value
+                  {:grammar ~(compile-grammar parseable-grammar)}))))
+
+(defn- format-dependencies-map [dependencies-map]
+  (->> dependencies-map
+       (map (fn [[k v]]
+              [k
+               `(or (:grammar (meta ~v))
+                    (:grammar ~v))]))
+       (into {})))
+
+(defmacro defrules
+  "Declare a set of composed rules. `dependencies` may be a list of
+   rules that will be merged in later, or a map of {dependency rule}
+   to merge in those dependencies directly"
+  ([name string-rules]
+   `(defrules ~name ~string-rules nil))
+  ([name string-rules dependencies]
+   (let [nop-names (if (map? dependencies)
+                     (keys dependencies)
+                     dependencies)
+         provided-rules (if (string? string-rules)
+                          [string-rules]
+                          string-rules)
+         compiled (-> provided-rules
+                      (concat
+                        (generate-grammar-nops nop-names))
+                      (->> (str/join "\n"))
+                      (compile-grammar)
+                      (as-> g
+                        (apply dissoc g nop-names)))
+         grammar (cond-> compiled
+                   (map? dependencies) (merge (format-dependencies-map
+                                                dependencies)))]
+     `(def ~name {:grammar ~grammar}))))

--- a/src/main/atc/util/with_timing.cljc
+++ b/src/main/atc/util/with_timing.cljc
@@ -1,0 +1,9 @@
+(ns atc.util.with-timing)
+
+(defmacro with-timing [label expr]
+  `(let [start# (js/Date.now)
+         ret# ~expr]
+     (prn (cljs.core/str ~(str "[" label "]") " Elapsed time: "
+                         (.toFixed (- (js/Date.now) start#) 6)
+                         " msecs"))
+     ret#))

--- a/src/main/atc/voice/parsing/airport.cljc
+++ b/src/main/atc/voice/parsing/airport.cljc
@@ -1,18 +1,15 @@
 (ns atc.voice.parsing.airport
   (:require
-   [atc.voice.parsing.core :refer [declare-alternates]]
    [clojure.string :as str]))
 
-(defn generate-parsing-context [airport]
-  (let [navaids-by-pronunciation (reduce
-                                   (fn [m {:keys [pronunciation name id]}]
-                                     (assoc m
-                                            (or pronunciation
-                                                (when name
-                                                  (str/lower-case name))
-                                                (str/lower-case id))
-                                            id))
-                                   {}
-                                   (:navaids airport))]
-    {:rules [(declare-alternates "navaid-pronounced" (keys navaids-by-pronunciation))]
-     :transformers {:navaid-pronounced navaids-by-pronunciation}}))
+(defn airport->navaids-by-pronunciation [airport]
+  (reduce
+    (fn [m {:keys [pronunciation name id]}]
+      (assoc m
+             (or pronunciation
+                 (when name
+                   (str/lower-case name))
+                 (str/lower-case id))
+             id))
+    {}
+    (:navaids airport)))

--- a/src/main/atc/voice/parsing/airport.cljc
+++ b/src/main/atc/voice/parsing/airport.cljc
@@ -14,10 +14,5 @@
                                             id))
                                    {}
                                    (:navaids airport))]
-    {:rules ["<navaid> = navaid-pronounced | navaid-spelled"
-             "navaid-spelled = (letter letter letter <'v o r'>?) | (letter letter letter letter letter <'intersection'>?)"
-
-             (declare-alternates "navaid-pronounced" (keys navaids-by-pronunciation))]
-     :transformers {:navaid-pronounced navaids-by-pronunciation
-                    :navaid-spelled (fn [& letters]
-                                      (str/join letters))}}))
+    {:rules [(declare-alternates "navaid-pronounced" (keys navaids-by-pronunciation))]
+     :transformers {:navaid-pronounced navaids-by-pronunciation}}))

--- a/src/main/atc/voice/parsing/callsigns.cljc
+++ b/src/main/atc/voice/parsing/callsigns.cljc
@@ -10,14 +10,14 @@
    "brickyard" "RPA"
    "south west" "SWA"})
 
-(defalternates ^:hide-tag plane-types
+(defalternates ^:hide-tag plane-type
   ["piper"])
 
 (defrules rules
   ["callsign = airline-callsign | ga-callsign"
    "airline-callsign = airline-names number-sequence"
    "ga-callsign = <('november' | plane-type)> number-sequence (letter-sequence)?"]
-  {:plane-type plane-types
+  {:plane-type plane-type
    :airline-names airline-names
    :number-sequence nil
    :letter-sequence nil}

--- a/src/main/atc/voice/parsing/callsigns.cljc
+++ b/src/main/atc/voice/parsing/callsigns.cljc
@@ -1,26 +1,30 @@
 (ns atc.voice.parsing.callsigns
   (:require
-   [atc.data.airlines :refer [all-airlines]]
-   [atc.voice.parsing.core :refer [declare-alternates]]))
+   [atc.util.instaparse :refer-macros [defalternates defrules]]))
 
-(def airlines
-  (->> all-airlines
-       (map (fn [[id {:keys [radio-name]}]]
-              [radio-name id]))
-       (into {})))
+(defalternates airline-names
+  {"american" "AAL"
+   "speed bird" "BAW"
+   "delta" "DAL"
+   "jet blue" "JBU"
+   "brickyard" "RPA"
+   "south west" "SWA"})
 
-(def plane-types
+(defalternates ^:hide-tag plane-types
   ["piper"])
 
-(def rules
+(defrules rules
   ["callsign = airline-callsign | ga-callsign"
    "airline-callsign = airline-names number-sequence"
-   "ga-callsign = <('november' | plane-type)> number-sequence (letter-sequence)?"
-   (declare-alternates "<plane-type>" plane-types)
-   (declare-alternates "airline-names" (keys airlines))])
+   "ga-callsign = <('november' | plane-type)> number-sequence (letter-sequence)?"]
+  {:plane-type plane-types
+   :airline-names airline-names
+   :number-sequence nil
+   :letter-sequence nil}
+   #_(declare-alternates "airline-names" (keys airlines)))
 
 (def transformers
-  {:airline-names airlines
+  {:airline-names airline-names
    :airline-callsign (fn [airline numbers]
                        (apply str airline numbers))
 

--- a/src/main/atc/voice/parsing/callsigns.cljc
+++ b/src/main/atc/voice/parsing/callsigns.cljc
@@ -1,14 +1,15 @@
 (ns atc.voice.parsing.callsigns
   (:require
-   [atc.util.instaparse :refer-macros [defalternates defrules]]))
+   [atc.data.airlines :refer [all-airlines]]
+   [atc.util.instaparse :refer-macros [defalternates
+                                       defalternates-expr
+                                       defrules]]))
 
-(defalternates airline-names
-  {"american" "AAL"
-   "speed bird" "BAW"
-   "delta" "DAL"
-   "jet blue" "JBU"
-   "brickyard" "RPA"
-   "south west" "SWA"})
+(defalternates-expr airline-names
+  (->> all-airlines
+       (into {}
+             (map (fn [[callsign {:keys [radio-name]}]]
+                    [radio-name callsign])))))
 
 (defalternates ^:hide-tag plane-type
   ["piper"])
@@ -20,8 +21,7 @@
   {:plane-type plane-type
    :airline-names airline-names
    :number-sequence nil
-   :letter-sequence nil}
-   #_(declare-alternates "airline-names" (keys airlines)))
+   :letter-sequence nil})
 
 (def transformers
   {:airline-names airline-names

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -1,17 +1,19 @@
 (ns atc.voice.parsing.instructions
   (:require
-   [atc.voice.parsing.core :refer [declare-alternates]]
+   [atc.util.instaparse :refer-macros [defalternates
+                                       defalternates-expr
+                                       defrules]]
    [clojure.string :as str]))
 
-(def handoffs
+(defalternates other-position
   ["center"
    "tower"
    "ground"])
 
-(def pleasantries
+(defalternates pleasantry
   ["good day"])
 
-(def ^:private instructions-rules
+(defrules ^:private instructions-rules
   ["standby = <'standby'>"
 
    "adjust-altitude = (<'climb'> | <'descend'>)? <'and'>? <'maintain'> altitude"
@@ -23,21 +25,27 @@
 
    "direct = <'proceed direct'> navaid"
 
-   "steer = (<'fly'> | 'turn right' | 'turn left') <'heading'> heading"])
+   "steer = (<'fly'> | 'turn right' | 'turn left') <'heading'> heading"]
 
-(def rules
-  (concat
-    ["command = callsign instruction+"
-     (str "<instruction> = " (->> instructions-rules
-                                  (map #(let [parts (str/split % #" = ")]
-                                          (first parts)))
-                                  (str/join " | ")))
+  [:other-position :pleasantry :frequency :navaid :altitude :approach-type :runway :heading])
 
-     "approach-type = 'i l s' | 'r nav' | 'visual'"
-     "runway = number-sequence (letter | 'left' | 'right' | 'north' | 'south')?"
-     (declare-alternates "other-position" handoffs)
-     (declare-alternates "pleasantry" pleasantries)]
-    instructions-rules))
+(defalternates-expr ^:hide-tag instruction
+  (->> instructions-rules
+       :grammar
+       keys
+       (map name)))
+
+(defrules rules
+  ["command = callsign instruction+"
+
+   "approach-type = 'i l s' | 'r nav' | 'visual'"
+   "runway = number-sequence (letter | 'left' | 'right' | 'north' | 'south')?"]
+  {:other-position other-position
+   :pleasantry pleasantry
+   :callsign nil
+   :instruction instruction
+   :number-sequence nil
+   :letter nil})
 
 (def transformers
   {:command (fn [callsign & instructions]

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -32,10 +32,9 @@
 (defalternates-expr ^:hide-tag instruction
   (->> instructions-rules
        :grammar
-       keys
-       (map name)))
+       keys))
 
-(defrules rules
+(defrules ^:private core-rules
   ["command = callsign instruction+"
 
    "approach-type = 'i l s' | 'r nav' | 'visual'"
@@ -46,6 +45,10 @@
    :instruction instruction
    :number-sequence nil
    :letter nil})
+
+(def rules (merge-with merge
+                       core-rules
+                       instructions-rules))
 
 (def transformers
   {:command (fn [callsign & instructions]

--- a/src/main/atc/voice/parsing/letters.cljc
+++ b/src/main/atc/voice/parsing/letters.cljc
@@ -1,8 +1,8 @@
 (ns atc.voice.parsing.letters
   (:require
-   [atc.voice.parsing.core :refer [declare-alternates]]))
+   [atc.util.instaparse :refer-macros [defalternates defrules]]))
 
-(def letter-values
+(defalternates letter
   {"alpha" "A"
    "bravo" "B"
    "charlie" "C"
@@ -30,10 +30,10 @@
    "yankee" "Y"
    "zulu" "Z"})
 
-(def rules
-  ["letter-sequence = letter+"
-   (declare-alternates "letter" (keys letter-values))])
+(defrules rules
+  "letter-sequence = letter+"
+  {:letter letter})
 
 (def transformers
-  {:letter letter-values
+  {:letter letter
    :letter-sequence (fn [& values] values)})

--- a/src/main/atc/voice/parsing/navaids.cljc
+++ b/src/main/atc/voice/parsing/navaids.cljc
@@ -1,0 +1,13 @@
+(ns atc.voice.parsing.navaids
+  (:require
+   [atc.util.instaparse :refer-macros [defrules]]
+   [clojure.string :as str]))
+
+(defrules rules
+  ["<navaid> = navaid-pronounced | navaid-spelled"
+   "navaid-spelled = (letter letter letter <'v o r'>?) | (letter letter letter letter letter <'intersection'>?)"]
+  [:letter :navaid-pronounced])
+
+(def transformers
+  {:navaid-spelled (fn [& letters]
+                     (str/join letters))})

--- a/src/main/atc/voice/parsing/numbers.cljc
+++ b/src/main/atc/voice/parsing/numbers.cljc
@@ -1,10 +1,10 @@
 (ns atc.voice.parsing.numbers
   (:require
-   [atc.voice.parsing.core :refer [declare-alternates]]))
+   [atc.util.instaparse :refer-macros [defalternates defrules]]))
 
 ; NOTE: The "correct" radio phonology should come later in the map
 ; so it's used instead of the "plain" word when we do map-invert
-(def digit-values
+(defalternates digit
   {"zero" 0
    "one" 1
    "two" 2
@@ -19,7 +19,9 @@
    "nine" 9
    "niner" 9})
 
-(def teens-values
+(def digit-values digit)
+
+(defalternates teens-value
   {"eleven" 11
    "twelve" 12
    "thirteen" 13
@@ -30,7 +32,9 @@
    "eighteen" 18
    "nineteen" 19})
 
-(def tens-values
+(def teens-values teens-value)
+
+(defalternates tens-value
   {"twenty" 20
    "thirty" 30
    "forty" 40
@@ -40,7 +44,7 @@
    "eighty" 80
    "ninety" 90})
 
-(def rules
+(defrules rules
   ["frequency = number-sequence? decimal number-sequence"
    "heading = number-sequence"
    "<altitude> = flight-level | altitude-thousands-feet"
@@ -52,10 +56,10 @@
    "number-sequence = number+"
    "number = digit | double-digit"
    "digit-sequence = digit+"
-   "double-digit = (tens-value digit) | teens-value"
-   (declare-alternates "digit" (keys digit-values))
-   (declare-alternates "tens-value" (keys tens-values))
-   (declare-alternates "teens-value" (keys teens-values))])
+   "double-digit = (tens-value digit) | teens-value"]
+  {:digit digit
+   :tens-value tens-value
+   :teens-value teens-value})
 
 (defn digits->number [digits]
   (loop [numbers (reverse digits)
@@ -70,8 +74,8 @@
 
 (def transformers
   {:digit digit-values
-   :tens-value tens-values
-   :teens-value teens-values
+   :tens-value tens-value
+   :teens-value teens-value
    :double-digit (fn [tens ones]
                    (if (some? ones)
                      (+ tens ones)

--- a/src/main/atc/voice/parsing/numbers.cljc
+++ b/src/main/atc/voice/parsing/numbers.cljc
@@ -19,8 +19,6 @@
    "nine" 9
    "niner" 9})
 
-(def digit-values digit)
-
 (defalternates teens-value
   {"eleven" 11
    "twelve" 12
@@ -31,8 +29,6 @@
    "seventeen" 17
    "eighteen" 18
    "nineteen" 19})
-
-(def teens-values teens-value)
 
 (defalternates tens-value
   {"twenty" 20
@@ -73,7 +69,7 @@
         (+ result (* multiplier (first numbers)))))))
 
 (def transformers
-  {:digit digit-values
+  {:digit digit
    :tens-value tens-value
    :teens-value teens-value
    :double-digit (fn [tens ones]

--- a/src/main/atc/voice/process.cljs
+++ b/src/main/atc/voice/process.cljs
@@ -11,7 +11,7 @@
    [instaparse.core :as insta]))
 
 (def builtin-rules (merge-with merge
-                     #_instructions/rules
+                     instructions/rules
                      navaids/rules
                      letters/rules
                      callsigns/rules
@@ -27,8 +27,7 @@
 (defn build-machine [airport-context]
   {:fsm (with-timing "build-machine"
           (-> (insta/parser
-                (str/join "\n" (concat instructions/rules
-                                       (:rules airport-context)
+                (str/join "\n" (concat (:rules airport-context)
                                        (instaparse/generate-grammar-nops
                                          (keys (:grammar builtin-rules)))))
                 :auto-whitespace :standard)

--- a/src/main/atc/voice/process.cljs
+++ b/src/main/atc/voice/process.cljs
@@ -1,29 +1,38 @@
 (ns atc.voice.process
   (:require
+   [atc.util.instaparse :as instaparse]
+   [atc.util.with-timing :refer-macros [with-timing]]
    [atc.voice.parsing.callsigns :as callsigns]
    [atc.voice.parsing.instructions :as instructions]
    [atc.voice.parsing.letters :as letters]
+   [atc.voice.parsing.navaids :as navaids]
    [atc.voice.parsing.numbers :as numbers]
    [clojure.string :as str]
    [instaparse.core :as insta]))
 
-(def builtin-rules (concat
-                     instructions/rules
+(def builtin-rules (merge-with merge
+                     #_instructions/rules
+                     navaids/rules
                      letters/rules
                      callsigns/rules
                      numbers/rules))
 
 (def builtin-transformers (merge
                             instructions/transformers
+                            navaids/transformers
                             letters/transformers
                             numbers/transformers
                             callsigns/transformers))
 
 (defn build-machine [airport-context]
-  {:fsm (time
-          (insta/parser
-            (str/join "\n" (concat builtin-rules (:rules airport-context)))
-            :auto-whitespace :standard))
+  {:fsm (with-timing "build-machine"
+          (-> (insta/parser
+                (str/join "\n" (concat instructions/rules
+                                       (:rules airport-context)
+                                       (instaparse/generate-grammar-nops
+                                         (keys (:grammar builtin-rules)))))
+                :auto-whitespace :standard)
+              (update :grammar merge builtin-rules)))
    :transformers (merge builtin-transformers (:transformers airport-context))})
 
 (defn- parse-input [machine input]

--- a/src/main/atc/voice/process.cljs
+++ b/src/main/atc/voice/process.cljs
@@ -2,6 +2,7 @@
   (:require
    [atc.data.airports :refer [airport-parsing-rules
                               airport-parsing-transformers]]
+   [atc.util.instaparse :refer [extract-grammar]]
    [atc.util.with-timing :refer-macros [with-timing]]
    [atc.voice.parsing.callsigns :as callsigns]
    [atc.voice.parsing.instructions :as instructions]
@@ -36,7 +37,7 @@
    {:fsm (with-timing "build-machine"
            (-> (merge
                  builtin-rules
-                 (:grammar airport-rules))
+                 (extract-grammar airport-rules))
                (insta/parser :start :command
                              :auto-whitespace :standard)))
     :transformers (merge builtin-transformers

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -1,13 +1,15 @@
 (ns atc.voice.process-test
   (:require
    [atc.data.airports.kjfk :as kjfk]
-   [atc.voice.parsing.airport :as airport-parsing]
    [atc.voice.process :rename {find-command actual-find-command} :refer [build-machine]]
    [cljs.test :refer-macros [deftest is testing]]))
 
 (def machine
   (delay
-    (build-machine (airport-parsing/generate-parsing-context kjfk/airport))))
+    (build-machine
+      (:navaid-pronounced kjfk/exports)
+      {:navaid-pronounced
+       (:navaids-by-pronunciation kjfk/exports)})))
 
 (defn find-command [input]
   (actual-find-command @machine input))
@@ -55,7 +57,10 @@
   (testing "Pronounceable navaids"
     (is (= [[:direct "MERIT"]]
            (find-instructions
-             "piper one proceed direct merit"))))
+             "piper one proceed direct merit")))
+    (is (= [[:direct "LGA"]]
+           (find-instructions
+             "piper one proceed direct la guardia"))))
 
   (testing "Spelled navaids"
     (is (= [[:direct "BDR"]]

--- a/src/tool/atc/tool.clj
+++ b/src/tool/atc/tool.clj
@@ -246,10 +246,25 @@
         (spit
           (io/file file-path)
           (str
-            (format "(ns atc.data.airports.%s)\n\n" icao-sym)
+            (format (str "(ns atc.data.airports.%s\n"
+                         " (:require\n"
+                         "  [atc.voice.parsing.airport :as parsing]\n"
+                         "  [atc.util.instaparse :refer-macros [defalternates-expr]]))\n\n")
+                    icao-sym)
             (with-out-str
               (pprint (cons (symbol "def airport")
-                            (list airport))))))
+                            (list airport))))
+            "\n\n"
+            "(def navaids-by-pronunciation\n"
+            "  (parsing/airport->navaids-by-pronunciation airport))"
+            "\n\n"
+            "(defalternates-expr navaid-pronounced\n"
+            "  (keys navaids-by-pronunciation))"
+            "\n\n"
+            "(def exports\n"
+            " {:airport airport\n"
+            "  :navaids-by-pronunciation navaids-by-pronunciation\n"
+            "  :navaid-pronounced navaid-pronounced})"))
         (println "... done!")))))
 
 (defn- pronounceable-cli [{{:keys [word]} :opts}]


### PR DESCRIPTION
Parsing the EBNF string grammar at runtime takes ~550ms. We originally took that approach because there wasn't an obvious way to programmatically generate parsing rules without using the string grammar format, and there also wasn't an officially sanctioned way to compose different sets of rules---which we *need* to do for airport-specific rules (currently, just the airport's navaids).

But it turns out the grammar is essentially a map of rules, so if we're a bit clever we can compose the rules together relatively easily. 550ms *once* at the beginning of a session isn't that big of a deal, but it *does* feel pretty nice!

- Experiment with using macros to generate parsers at compile time
- Precompile instructions rules
- Precompile airport context parsing data + fix rule merging, etc.
- Clean up an accomplished TODO!
