### PR TITLE
Support using "disregard" to ignore the previous input

### DIFF
--- a/src/main/atc/voice/parsing/core.cljc
+++ b/src/main/atc/voice/parsing/core.cljc
@@ -1,4 +1,4 @@
-(ns atc.voice.parsing.core 
+(ns atc.voice.parsing.core
   (:require
    [clojure.string :as str]))
 

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -15,6 +15,7 @@
 
 (defrules ^:private instructions-rules
   ["standby = <'standby'>"
+   "disregard = <'disregard'>"
 
    "adjust-altitude = (<'climb'> | <'descend'>)? <'and'>? <'maintain'> altitude"
 

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -54,7 +54,16 @@
                             "piper one fly heading two three four have fun")]
          (is (= [[:steer 234]]
                 (pop instructions)))
-         (is (= :error (-> instructions last first)))))))
+         (is (= :error (-> instructions last first))))))
+
+   (testing "Ignore everything before a disregard"
+     ; When we *end* with disregard... ignore the entire thing!
+     (is (nil?
+           (find-command "piper one proceed direct disregard")))
+
+     (is (= {:callsign "N2"
+             :instructions [[:direct "JFK"]]}
+            (find-command "piper one proceed direct disregard piper two proceed disregard piper two proceed direct kennedy")))))
 
 (deftest navaid-test
   (testing "Pronounceable navaids"


### PR DESCRIPTION
Fixes #16

It seems like we don't need to actually deeply integrate "disregard"
into the grammar for Vosk to accept it in random places, and we can just
pre-process the text as a special case.
