### PR TITLE
Support repositioning aircraft datablocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "private": true,
     "dependencies": {
         "@inlet/react-pixi": "^6.8.0",
+        "@pixi/math-extras": "^6.5.1",
         "microphone-stream": "^6.0.1",
         "pixi-viewport": "^4.34.4",
         "pixi.js": "^6.5.1",

--- a/src/main/atc/core.cljs
+++ b/src/main/atc/core.cljs
@@ -1,5 +1,6 @@
 (ns atc.core
   (:require
+    ["@pixi/math-extras"]
     [goog.dom :as gdom]
     [reagent.dom :as rdom]
     [re-frame.core :as re-frame]

--- a/src/main/atc/theme.cljs
+++ b/src/main/atc/theme.cljs
@@ -14,3 +14,4 @@
 (def aircraft-tracked-label "#ffffff")
 (def aircraft-tracked-obj "#1f478f")
 (def aircraft-untracked-obj "#00ff00")
+(def aircraft-untracked-obj-int 0x00ff00)

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -76,11 +76,10 @@
                  :style tracked-label-style}]))
 
 (defn- tracked [craft]
-  ; TODO: Adjust label location?
   [:<>
    [tracked-position-symbol]
 
-   [data-block-positioning
+   [data-block-positioning {:tracked? true}
     [full-data-block craft]]])
 
 (defn- untracked [{{altitude :z} :position}
@@ -92,7 +91,7 @@
                 :style untracked-aircraft-style
                 :text (or track-symbol "＊")}]
    (when track-symbol
-     [data-block-positioning
+     [data-block-positioning {:tracked? false}
       [:> px/Text {:text (format-altitude altitude)
                    :anchor {:x 0 :y 0.5}
                    :style untracked-aircraft-style}]])])
@@ -104,7 +103,6 @@
   (let [tracked-map (<sub [:game/tracked-aircraft-map])
         track (get tracked-map callsign)
         self-tracked? (:self? track)]
-    ; TODO render different graphics based on aircraft state
     (cond
       self-tracked? [tracked craft]
       (some? track) [untracked craft track]

--- a/src/main/atc/views/game/graphics/aircraft.cljs
+++ b/src/main/atc/views/game/graphics/aircraft.cljs
@@ -5,7 +5,7 @@
    [archetype.util :refer [<sub >evt]]
    [atc.data.units :as units]
    [atc.theme :as theme]
-   [atc.views.game.graphics.line :refer [line]]
+   [atc.views.game.graphics.data-block-positioning :refer [data-block-positioning]]
    [clojure.math :refer [floor]]
    [clojure.string :as str]))
 
@@ -40,15 +40,6 @@
 
 ; ======= Rendering =======================================
 
-(defn- data-block-positioning [_craft block]
-  [:<>
-   ; TODO choose color based on tracked state
-   [line {:from {:x 10 :y 0}
-          :to {:x 20 :y 0}
-          :color 0xffffff}]
-
-   [:> px/Container {:x 28 :y 0}
-    block]])
 
 (defn- tracked-position-symbol []
   [:> px/Text {:text "⬤"
@@ -89,10 +80,10 @@
   [:<>
    [tracked-position-symbol]
 
-   [data-block-positioning craft
+   [data-block-positioning
     [full-data-block craft]]])
 
-(defn- untracked [{{altitude :z} :position :as craft}
+(defn- untracked [{{altitude :z} :position}
                   {:keys [track-symbol] :as track}]
   [:<>
    [:> px/Text {:anchor 0.5
@@ -101,7 +92,7 @@
                 :style untracked-aircraft-style
                 :text (or track-symbol "＊")}]
    (when track-symbol
-     [data-block-positioning craft
+     [data-block-positioning
       [:> px/Text {:text (format-altitude altitude)
                    :anchor {:x 0 :y 0.5}
                    :style untracked-aircraft-style}]])])

--- a/src/main/atc/views/game/graphics/data_block_positioning.cljs
+++ b/src/main/atc/views/game/graphics/data_block_positioning.cljs
@@ -1,0 +1,78 @@
+(ns atc.views.game.graphics.data-block-positioning
+  (:require
+   ["@inlet/react-pixi" :as px]
+   ["@pixi/math-extras"]
+   ["pixi.js" :refer [Point]]
+   [applied-science.js-interop :as j]
+   [atc.views.game.graphics.line :refer [line]]
+   [clojure.math :refer [atan2 round]]
+   [reagent.core :as r]))
+
+(def ^:private angle-interval (/ js/Math.PI 4))
+(def ^:private angle-vectors
+  {0 (Point. 1 0)
+   1 (.normalize (Point. 1 1))
+   2 (Point. 0 1)
+   3 (.normalize (Point. -1 1))
+   4 (Point. -1 0)
+   -4 (Point. -1 0)
+   -3 (.normalize (Point. -1 -1))
+   -2 (Point. 0 -1)
+   -1 (.normalize (Point. 1 -1))})
+
+(defn- handle-drag [state e]
+  (cond-> state
+    (:dragging? state)
+    (as-> s
+      (let [mouse-x (j/get-in e [:data :global :x])
+            mouse-y (j/get-in e [:data :global :y])
+            ref-x (j/get (:reference s) :x)
+            ref-y (j/get (:reference s) :y)
+            angle (atan2 (- mouse-y ref-y)
+                         (- mouse-x ref-x))
+            rounded-angle (round (/ angle angle-interval))]
+        (assoc s
+               :length (-> (.subtract
+                             (j/get-in e [:data :global])
+                             (:reference s))
+                           (.magnitude)
+                           (abs)
+                           (max 10))
+               :angle (get angle-vectors rounded-angle))))))
+
+(defn data-block-positioning [block]
+  (r/with-let [datablock-state (r/atom {:dragging? false
+                                        :angle (get angle-vectors 0)
+                                        :length 10})
+               on-down (fn [e]
+                         (.stopPropagation e)
+                         (swap!
+                           datablock-state assoc
+                           :dragging? true
+                           :reference (j/call-in e [:target :parent
+                                                    :getGlobalPosition])))
+               on-up (fn [e]
+                       (when (:dragging? @datablock-state)
+                         (.stopPropagation e)
+                         (swap! datablock-state assoc :dragging? false)))
+               on-move (fn [e]
+                         (swap! datablock-state handle-drag e))]
+    (let [{:keys [^js angle] :as state} @datablock-state
+          line-start (.multiplyScalar angle 10)
+          line-length (.multiplyScalar angle (:length state))
+          line-end (.add line-start line-length)
+          container-pos (.add line-end line-start)]
+      [:<>
+       ; TODO choose color based on tracked state
+       [line {:from line-start
+              :to line-end
+              :color 0xffffff}]
+
+       [:> px/Container {:interactive true
+                         :pointerdown on-down
+                         :pointerup on-up
+                         :pointerupoutside on-up
+                         :pointermove on-move
+                         :x (j/get container-pos :x)
+                         :y (j/get container-pos :y)}
+        block]])))

--- a/src/main/atc/views/game/graphics/data_block_positioning.cljs
+++ b/src/main/atc/views/game/graphics/data_block_positioning.cljs
@@ -4,6 +4,7 @@
    ["@pixi/math-extras"]
    ["pixi.js" :refer [Point]]
    [applied-science.js-interop :as j]
+   [atc.theme :as theme]
    [atc.views.game.graphics.line :refer [line]]
    [clojure.math :refer [atan2 round]]
    [reagent.core :as r]))
@@ -40,7 +41,7 @@
                            (max 10))
                :angle (get angle-vectors rounded-angle))))))
 
-(defn data-block-positioning [block]
+(defn data-block-positioning [{:keys [tracked?]} block]
   (r/with-let [datablock-state (r/atom {:dragging? false
                                         :angle (get angle-vectors 0)
                                         :length 10})
@@ -63,10 +64,11 @@
           line-end (.add line-start line-length)
           container-pos (.add line-end line-start)]
       [:<>
-       ; TODO choose color based on tracked state
        [line {:from line-start
               :to line-end
-              :color 0xffffff}]
+              :color (if tracked?
+                       0xffffff
+                       theme/aircraft-untracked-obj-int)}]
 
        [:> px/Container {:interactive true
                          :cursor :grab

--- a/src/main/atc/views/game/graphics/data_block_positioning.cljs
+++ b/src/main/atc/views/game/graphics/data_block_positioning.cljs
@@ -69,6 +69,7 @@
               :color 0xffffff}]
 
        [:> px/Container {:interactive true
+                         :cursor :grab
                          :pointerdown on-down
                          :pointerup on-up
                          :pointerupoutside on-up

--- a/src/main/atc/views/game/graphics/line.cljs
+++ b/src/main/atc/views/game/graphics/line.cljs
@@ -1,6 +1,14 @@
 (ns atc.views.game.graphics.line
   (:require
-   ["@inlet/react-pixi" :as px]))
+   ["@inlet/react-pixi" :as px]
+   [applied-science.js-interop :as j]))
+
+(defn- unpack-coord [v]
+  (if (map? v)
+    [(:x v 0)
+     (:y v 0)]
+    [(j/get v :x 0)
+     (j/get v :y 0)]))
 
 (defn line [{:keys [from to width color alpha]
              :or {width 1
@@ -8,8 +16,10 @@
   (when-not (int? color)
     (js/console.warn ":color should be an int!"))
   [:> px/Graphics {:draw (fn draw [^js g]
-                           (doto g
-                             (.clear)
-                             (.lineStyle width color alpha)
-                             (.moveTo (:x from 0) (:y from 0))
-                             (.lineTo (:x to) (:y to))))}])
+                           (let [[fx fy] (unpack-coord from)
+                                 [tx ty] (unpack-coord to)]
+                             (doto g
+                               (.clear)
+                               (.lineStyle width color alpha)
+                               (.moveTo fx fy)
+                               (.lineTo tx ty))))}])

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,6 +99,11 @@
   resolved "https://registry.yarnpkg.com/@pixi/loaders/-/loaders-6.5.1.tgz#148e2d7e5b30bd81dab4941a857a01b92c5aa65e"
   integrity sha512-3a41RWFWyRtBrs/fboaFHLF7H5uof4XaWqMCxvLzfofHiz2AuiZnAx9YJAjT+RCP2uFfoU1XmDcyGdc1Q0Ib4w==
 
+"@pixi/math-extras@^6.5.1":
+  version "6.5.10"
+  resolved "https://registry.yarnpkg.com/@pixi/math-extras/-/math-extras-6.5.10.tgz#907338a877dbd371df0a161ef13afa5a43fcac67"
+  integrity sha512-TG2zzvdV0F7FmZtsjSrW12ub+QUZadBRCQZt0IaxTl6VBhysBaYhPILC5YpfGhim1uuF1L8W0LLWaGLI8T3VNg==
+
 "@pixi/math@6.5.1":
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/@pixi/math/-/math-6.5.1.tgz#16213190e19400a77067442406e0e5ef206c3cd7"


### PR DESCRIPTION
Just click and drag!

- Add basic support for repositioning datablocks
- Use the :grab cursor on the datablock
- Change the datablock line color by tracked state
- Adjust the datablock position to better match the cursor

https://github.com/dhleong/cljs-atc/assets/816150/0b01ec7a-dd0b-4e39-8c99-a090fc9e7431

To be *very* robust we probably should store this state on the craft in reframe instead of only in the component....