### PR TITLE
Fix overlapping arrivals due to overlapping fixes

### DIFF
--- a/src/main/atc/config.cljc
+++ b/src/main/atc/config.cljc
@@ -2,7 +2,7 @@
   (:require
    [atc.data.units :refer [nm->m]]))
 
-(goog-define server-root "")
+#?(:cljs (goog-define server-root ""))
 
 ; Aircraft may not exceed 250kts below 10K ft
 (def speed-limit-under-10k-kts 250)

--- a/src/main/atc/data/airports/kjfk.cljc
+++ b/src/main/atc/data/airports/kjfk.cljc
@@ -733,6 +733,7 @@
     :position [:N40*00'24.320 :W074*15'04.610],
     :type :fix}],
   :id "KJFK",
+  :arrival-navaid-grouping {"GAMBY" "CAMRN"},
   :center-facilities
   [{:id "COLTS NECK",
     :position [:N40*18'42.000 :W074*09'37.000],

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -39,10 +39,10 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defprotocol Vector
-  (v+ [this ^Vector other])
-  (v- [this ^Vector other])
+  (v+ [this other])
+  (v- [this other])
   (v* [this other])
-  (dot* [this ^Vector other])
+  (dot* [this other])
   (vmag2 [this] "Compute the square of the magnitude of this vector"))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
@@ -83,7 +83,7 @@
          (* dy dy)
          (* dz dz)))))
 
-(defn vmag [^Vector v]
+(defn vmag [v]
   (sqrt (vmag2 v)))
 
 (def vec3? (partial instance? Vec3))
@@ -96,7 +96,7 @@
   ([x y z]
    (->Vec3 x y z)))
 
-(defn normalize [^Vector v]
+(defn normalize [v]
   (let [magnitude (vmag v)]
     (v* v (/ 1 magnitude))))
 

--- a/src/main/atc/game/traffic/shared_test.cljs
+++ b/src/main/atc/game/traffic/shared_test.cljs
@@ -3,9 +3,10 @@
    [atc.config :as config]
    [atc.data.airports.kjfk :as kjfk]
    [atc.engine.model :refer [distance-to-squared lateral-distance-to-squared]]
-   [atc.game.traffic.shared :as shared :refer [partial-arrival-route
+   [atc.game.traffic.shared :as shared :refer [grouping-navaid-of-route
                                                position-arriving-aircraft]]
-   [atc.subs :refer [navaids-by-id]]
+   [atc.game.traffic.shared-util :refer [partial-arrival-route]]
+   [atc.subs-util :refer [navaids-by-id]]
    [atc.util.testing :refer [roughly=]]
    [cljs.test :refer-macros [deftest is testing]]
    [clojure.math :refer [sqrt]]))
@@ -59,20 +60,21 @@
       (when-not (== c1 c2)
         (let [engine (create-engine)
               c1-partial-route (partial-arrival-route engine c1)
+              c1-grouping (grouping-navaid-of-route engine c1-partial-route)
               c2-partial-route (partial-arrival-route engine c2)
+              c2-grouping (grouping-navaid-of-route engine c2-partial-route)
               delta (/ config/lateral-spacing-m 2)]
           (assert (not (roughly= (:position c1) (:position c2)
                                  :delta delta))
                   (str "\nOVERLAP! " (sqrt (distance-to-squared
                                              (:position c1)
                                              (:position c2)))  "m\n"
-                       " " (:callsign c1) " (" (:route c1)
-                       "\n -> " c1-partial-route ")\n"
+                       " " (:callsign c1) " (" (:route c1) ")"
+                       "\n -> " c1-partial-route " @ " c1-grouping "\n"
                        "COLLIDED with:\n"
-                       " " (:callsign c2) " (" (:route c2)
-                       "\n -> " c2-partial-route ")\n"
-                       "same navaid? " (= (last c1-partial-route)
-                                          (last c2-partial-route)))))))))
+                       " " (:callsign c2) " (" (:route c2) ")"
+                       "\n -> " c2-partial-route " @ " c2-grouping "\n"
+                       "same navaid? " (= c1-grouping c2-grouping))))))))
 
 (deftest position-arriving-aircraft-test
   (testing "Handle single-item route"

--- a/src/main/atc/game/traffic/shared_test.cljs
+++ b/src/main/atc/game/traffic/shared_test.cljs
@@ -2,7 +2,7 @@
   (:require
    [atc.config :as config]
    [atc.data.airports.kjfk :as kjfk]
-   [atc.engine.model :refer [lateral-distance-to-squared]]
+   [atc.engine.model :refer [distance-to-squared lateral-distance-to-squared]]
    [atc.game.traffic.shared :as shared :refer [partial-arrival-route
                                                position-arriving-aircraft]]
    [atc.subs :refer [navaids-by-id]]
@@ -52,6 +52,28 @@
           (next origins)
           (conj crafts craft))))))
 
+(defn- assert-no-overlap [crafts]
+  (doall
+    (for [c1 crafts
+          c2 crafts]
+      (when-not (== c1 c2)
+        (let [engine (create-engine)
+              c1-partial-route (partial-arrival-route engine c1)
+              c2-partial-route (partial-arrival-route engine c2)
+              delta (/ config/lateral-spacing-m 2)]
+          (assert (not (roughly= (:position c1) (:position c2)
+                                 :delta delta))
+                  (str "\nOVERLAP! " (sqrt (distance-to-squared
+                                             (:position c1)
+                                             (:position c2)))  "m\n"
+                       " " (:callsign c1) " (" (:route c1)
+                       "\n -> " c1-partial-route ")\n"
+                       "COLLIDED with:\n"
+                       " " (:callsign c2) " (" (:route c2)
+                       "\n -> " c2-partial-route ")\n"
+                       "same navaid? " (= (last c1-partial-route)
+                                          (last c2-partial-route)))))))))
+
 (deftest position-arriving-aircraft-test
   (testing "Handle single-item route"
     ; NOTE: KBWI just ends at CAMRN
@@ -99,25 +121,16 @@
     ; A sample random set of arrivals from a real app run that caused one
     ; overlap
     (let [{crafts :crafts} (spawn-crafts-from
-                             "KCRQ" "KBUR" "KPHX" "KSMO" "KFMY" "KRDU"
-                             "CYYZ" "KRDU" "KORD" "KTRM")]
-      (loop [crafts crafts
-             distincts {}]
-        (when (seq crafts)
-          (let [c (first crafts)
-                existing (get distincts (:position c))]
-            (assert
-              (nil? existing)
-              (str "\nOVERLAP!\n"
-                   (:callsign c) " (" (:route c) ")\n"
-                   "COLLIDED with:\n"
-                   (:callsign existing) " (" (:route existing) ")\n"
-                   "same navaid? " (= (last (partial-arrival-route
-                                              (create-engine)
-                                              existing))
-                                      (last (partial-arrival-route
-                                              (create-engine)
-                                              c)))))
-            (recur (next crafts)
-                   (assoc distincts (:position c) c)))))
+                             "KCRQ" "KBUR" "KPHX" "KSMO" "KFMY"
+                             "KRDU" "CYYZ" "KRDU" "KORD" "KTRM")]
+      (assert-no-overlap crafts)
+      (is (= 10 (count (distinct (map :position crafts)))))))
+
+  (testing "No overlap, for reals - pt2"
+    ; A sample random set of arrivals from a real app run that caused one
+    ; overlap
+    (let [{crafts :crafts} (spawn-crafts-from
+                             "KRSW" "KHYA" "KCVG" "KCRQ" "KLAX"
+                             "KPWM" "KORF" "KIAD" "KSAT" "KIND")]
+      (assert-no-overlap crafts)
       (is (= 10 (count (distinct (map :position crafts))))))))

--- a/src/main/atc/game/traffic/shared_util.cljc
+++ b/src/main/atc/game/traffic/shared_util.cljc
@@ -1,0 +1,18 @@
+(ns atc.game.traffic.shared-util
+  (:require
+   [clojure.string :as str]))
+
+(defn partial-arrival-route [engine {:keys [route]}]
+  (->>
+    (str/split route #" ")
+    (drop-last)
+    (take-last 2)
+    (mapcat (fn [id]
+              (or (->> (get-in engine [:airport :arrivals id :path])
+                       (map :fix)
+                       (drop-last)
+                       (seq))
+                  (when (get-in engine [:game/navaids-by-id id])
+                    [id]))))
+    (distinct)
+    (vec)))

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -4,6 +4,7 @@
    [atc.data.core :refer [local-xy]]
    [atc.engine.model :refer [v* vec3]]
    [atc.structures.rolling-history :refer [most-recent-n]]
+   [atc.subs-util :refer [navaids-by-id]]
    [atc.util.subs :refer [get-or-identity]]
    [clojure.math :refer [floor]]
    [clojure.string :as str]
@@ -137,15 +138,6 @@
   :<- [::engine]
   :-> :airport)
 
-(defn navaids-by-id [airport]
-  (some->>
-    airport
-    :navaids
-    (reduce
-      (fn [m {:keys [position] :as navaid}]
-        (assoc m (:id navaid)
-               (merge navaid (local-xy position airport))))
-      {})))
 
 (reg-sub
   :game/navaids-by-id

--- a/src/main/atc/subs_util.cljc
+++ b/src/main/atc/subs_util.cljc
@@ -1,0 +1,13 @@
+(ns atc.subs-util
+  (:require
+   [atc.data.core :refer [local-xy]]))
+
+(defn navaids-by-id [airport]
+  (some->>
+    airport
+    :navaids
+    (reduce
+      (fn [m {:keys [position] :as navaid}]
+        (assoc m (:id navaid)
+               (merge navaid (local-xy position airport))))
+      {})))

--- a/src/main/atc/util/testing.cljc
+++ b/src/main/atc/util/testing.cljc
@@ -15,9 +15,10 @@
    (let [a (maybe->vec3 a)
          b (maybe->vec3 b)
          distance (if (number? a)
-                    ; The compiler doens't believe us, but these
+                    ; The compiler doesn't believe us, but these
                     ; *should* both be numbers. Let's reassure it!
-                    (- ^number a ^number b)
+                    #?(:cljs (- ^number a ^number b)
+                       :clj (- a b))
                     (vmag (v- a b)))]
      (<= (abs distance)
          delta))))

--- a/src/tool/atc/commands/build_airport.clj
+++ b/src/tool/atc/commands/build_airport.clj
@@ -1,0 +1,38 @@
+(ns atc.commands.build-airport
+  (:require
+   [atc.config :as config]
+   [atc.engine.model :refer [vec3]]
+   [atc.game.traffic.shared-util :refer [partial-arrival-route]]
+   [atc.subs-util :refer [navaids-by-id]]
+   [atc.util.testing :refer [roughly=]]))
+
+(defn- overlapping-navaids [navaids]
+  (->> (for [n1 navaids
+             n2 navaids]
+         (when-not (= n1 n2)
+           (when (roughly= (vec3 n1 0) (vec3 n2 0)
+                           :delta (/ config/lateral-spacing-m 2))
+             #{(:id n1) (:id n2)})))
+       (keep identity)
+       (distinct)
+       (map vec)))
+
+(defn augment-airport [airport]
+  (let [engine {:airport airport
+                :game/navaids-by-id (navaids-by-id airport)}
+        arrival-navaids (->> airport
+                             :arrival-routes
+                             vals
+                             (map (comp
+                                    last
+                                    (partial partial-arrival-route engine)))
+                             (distinct)
+                             (map #(get-in engine [:game/navaids-by-id %])))
+
+        ; A map of fix -> fix for all pairs of navaids that are
+        ; unacceptably close together.
+        arrival-navaid-grouping (->> arrival-navaids
+                                     (overlapping-navaids)
+                                     (into {}))]
+    (merge airport
+             {:arrival-navaid-grouping arrival-navaid-grouping})))

--- a/src/tool/atc/tool.clj
+++ b/src/tool/atc/tool.clj
@@ -1,5 +1,6 @@
 (ns atc.tool
   (:require
+   [atc.commands.build-airport :refer [augment-airport]]
    [atc.data.core :refer [coord-distance]]
    [atc.kmz :as kmz]
    [atc.nasr :as nasr]
@@ -283,7 +284,8 @@
         kmz-file (kmz/locate-kmz airac destination-dir)
 
         airport (with-timing "build-airport"
-                  (build-airport zip-file kmz-file icao))]
+                  (-> (build-airport zip-file kmz-file icao)
+                      (augment-airport)))]
     (pprint airport)
 
     (when-let [unpronounceable (with-timing "unpronounceable"


### PR DESCRIPTION
- Add a test to verify handling of very-close arrival fixes
- Pre-compute "grouped" arrival fixes and use to further prevent overlap
