### PR TITLE
Persist last game options to local-storage

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -21,6 +21,7 @@
                 ; util:
                 [applied-science/js-interop "0.2.7"]
                 [com.cemerick/url "0.1.1"]
+                [com.cognitect/transit-cljs "0.8.280"]
                 [dev.weavejester/medley "1.7.0"]
                 [funcool/promesa "11.0.671"]
                 [re-frame-utils "0.1.0"]

--- a/src/main/atc/config.cljc
+++ b/src/main/atc/config.cljc
@@ -4,6 +4,12 @@
 
 #?(:cljs (goog-define server-root ""))
 
+(def default-game-options
+  {:airport-id :kjfk
+   :arrivals? true
+   :departures? true
+   :use-voice-input true})
+
 ; Aircraft may not exceed 250kts below 10K ft
 (def speed-limit-under-10k-kts 250)
 

--- a/src/main/atc/db.cljs
+++ b/src/main/atc/db.cljs
@@ -19,4 +19,3 @@
    :speech {:available? nil
             :speaking? false
             :queue #queue []}})
-

--- a/src/main/atc/fx.cljs
+++ b/src/main/atc/fx.cljs
@@ -4,6 +4,7 @@
    [archetype.util :refer [>evt]]
    [atc.game :as game]
    [atc.speech :as speech]
+   [atc.util.local-storage :as local-storage]
    [atc.voice.core :as voice]
    [atc.voice.process :refer [find-command]]
    [promesa.core :as p]
@@ -14,6 +15,14 @@
 (reg-fx
   :nav/replace!
   nav/replace!)
+
+
+; ======= Persistence =====================================
+
+(reg-fx
+  :local-storage/save
+  (fn [[key data]]
+    (local-storage/save key data)))
 
 
 ; ======= Game setup ======================================

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -27,6 +27,9 @@
   :<- [::ui-config]
   :=> get-or-identity)
 
+(reg-sub
+  :game-options
+  :-> :game-options)
 
 ; ======= Voice ===========================================
 

--- a/src/main/atc/util/interceptors.cljs
+++ b/src/main/atc/util/interceptors.cljs
@@ -1,0 +1,21 @@
+(ns atc.util.interceptors
+  (:require
+   [re-frame.core :refer [->interceptor get-coeffect get-effect]]
+   [re-frame.interceptor :refer [assoc-effect]]))
+
+(defn persist-key
+  ([data-key] (persist-key data-key :as data-key))
+  ([db-key _ data-key]
+   (->interceptor
+     :id (keyword "persist-key" (name data-key))
+     :after (fn [context]
+              (let [initial-prefs (db-key (get-coeffect context :db {}) ::not-found)
+                    resulting-prefs (db-key (get-effect context :db {}) ::not-found)]
+                (if-not (or (= ::not-found initial-prefs)
+                            (= ::not-found resulting-prefs)
+                            (= initial-prefs resulting-prefs))
+                  (assoc-effect
+                    context
+                    :local-storage/save
+                    [data-key resulting-prefs])
+                  context))))))

--- a/src/main/atc/util/local_storage.cljs
+++ b/src/main/atc/util/local_storage.cljs
@@ -1,0 +1,18 @@
+(ns atc.util.local-storage
+  (:require
+   [cognitect.transit :as t]
+   [re-frame.core :refer [reg-cofx]]))
+
+(defn load [data-key]
+  (->> (js/window.localStorage.getItem (name data-key))
+       (t/read (t/reader :json))))
+
+(defn save [data-key data]
+  (->> data
+       (t/write (t/writer :json))
+       (js/window.localStorage.setItem (name data-key))))
+
+(reg-cofx
+  ::load
+  (fn [cofx data-key]
+    (assoc cofx data-key (load data-key))))

--- a/src/main/atc/views/game_setup.cljs
+++ b/src/main/atc/views/game_setup.cljs
@@ -1,6 +1,7 @@
 (ns atc.views.game-setup
   (:require
    [archetype.util :refer [<sub >evt]]
+   [atc.config :as config]
    [atc.data.airports :refer [list-airports]]
    [atc.styles :refer [full-screen]]
    [garden.units :refer [px]]
@@ -77,7 +78,7 @@
   [:.spacer {:height (px 8)}])
 
 (defn- start-game! [loading?-ref ^js e
-                    {:keys [airport-id use-voice-input
+                    {:keys [airport-id voice-input?
                             arrivals? departures?]}]
   (.preventDefault e)
   (p/do
@@ -86,7 +87,7 @@
     (>evt [:game/init {:airport-id airport-id
                        :arrivals? arrivals?
                        :departures? departures?
-                       :voice-input? use-voice-input}])))
+                       :voice-input? voice-input?}])))
 
 (defn- labeled-input [{:keys [type disabled label key]}]
   [:div.labeled
@@ -97,10 +98,8 @@
            :id key}]])
 
 (defn view []
-  (r/with-let [form-value (r/atom {:airport-id :kjfk
-                                   :arrivals? true
-                                   :departures? true
-                                   :use-voice-input true})
+  (r/with-let [form-value (r/atom (or (<sub [:game-options])
+                                      config/default-game-options))
                loading? (r/atom false)
                on-start-game (partial start-game! loading?)]
     [:div (setup-container-attrs)
@@ -144,7 +143,7 @@
         [labeled-input {:type :checkbox
                         :disabled @loading?
                         :label "Use voice input"
-                        :key :use-voice-input}]
+                        :key :voice-input?}]
         [:div.explanation {:id ::voice-explanation}
          "If enabled, you will be prompted to allow microphone input once the game is loaded. You can then hold the spacebar to activate the mic and talk to pilots on your frequency!"]]
 


### PR DESCRIPTION
Closes #30

Includes useful cofx for reading synchronously from local storage, and
an interceptor for writing changes back to local storage, in case
there's anything else we want to persist in the future.
