### PR TITLE
Add simple weather / ATIS support

### DIFF
--- a/src/main/atc/data/airports/kjfk.cljc
+++ b/src/main/atc/data/airports/kjfk.cljc
@@ -496,6 +496,20 @@
    {:route
     "KSBP LAS BAWER LARVE EKR BFF FOD DBQ KG75M DAFLU J70 LVZ LENDY8 KJFK"},
    "KSYR" {:route "KSYR HNK IGN IGN1 KJFK"}},
+  :runway-selection
+  (fn
+   [weather]
+   (let
+    [wind-heading (:wind-heading weather)]
+    (cond
+     (<= 85 wind-heading 220)
+     {:arrivals ["13R"], :departures ["13L"]}
+     (<= -5 wind-heading 130)
+     {:arrivals ["04R"], :departures ["04L"]}
+     (<= 265 wind-heading 400)
+     {:arrivals ["31L"], :departures ["31R"]}
+     (<= 175 wind-heading 310)
+     {:arrivals ["22L"], :departures ["22R"]}))),
   :navaids
   [{:id "ACOVE",
     :position [:N42*14'05.220 :W074*01'54.590],

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -122,7 +122,8 @@
   :verify-atis
   [craft _context [_ letter]]
   (-> craft
-      (utter "we have " [:letter letter])))
+      (utter "we have " [:letter letter])
+      (update :behavior assoc :will-get-weather? true)))
 
 (defmethod dispatch-instruction
   :default

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -119,6 +119,12 @@
   craft)
 
 (defmethod dispatch-instruction
+  :verify-atis
+  [craft _context [_ letter]]
+  (-> craft
+      (utter "we have " [:letter letter])))
+
+(defmethod dispatch-instruction
   :default
   [craft _context [instruction]]
   (println "TODO: Unhandled craft instruction: " instruction)

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -121,6 +121,9 @@
 (defmethod dispatch-instruction
   :verify-atis
   [craft _context [_ letter]]
+  ; TODO: This is a bit of laziness; a more complete simulation might
+  ; have some aircraft who have an *old* ATIS (or haven't gotten any)
+  ; and need to a) go get it, and b) report back when they have it
   (-> craft
       (utter "we have " [:letter letter])
       (update :behavior assoc :will-get-weather? true)))

--- a/src/main/atc/engine/aircraft/states.cljs
+++ b/src/main/atc/engine/aircraft/states.cljs
@@ -73,7 +73,12 @@
               {:from (aircraft/build-utterance-from aircraft)
                ; TODO: include approach/departure "name"
                ; (eg: "New York Departure")
-               :message [named-position ", " aircraft ". With you"
+               :message [named-position ", " aircraft ". "
+                         (cond
+                           (get-in aircraft [:behavior :will-get-weather?])
+                           (str "With the weather,")
+
+                           :else "With you")
                          [:altitude
                           (round-to-hundreds
                             (m->ft (:z (:position aircraft))))]

--- a/src/main/atc/engine/global.cljs
+++ b/src/main/atc/engine/global.cljs
@@ -5,7 +5,7 @@
 (defmulti dispatch-global-instruction (fn [_engine [instruction]] instruction))
 
 (defmethod dispatch-global-instruction
-  :update-atis
+  :atis-update
   [engine [_ letter]]
   ; TODO This should probably reward/deduct points.
   ; TODO We should check if they've already done this or not

--- a/src/main/atc/engine/global.cljs
+++ b/src/main/atc/engine/global.cljs
@@ -1,0 +1,20 @@
+(ns atc.engine.global
+  (:require
+   [archetype.util :refer [>evt]]))
+
+(defmulti dispatch-global-instruction (fn [_engine [instruction]] instruction))
+
+(defmethod dispatch-global-instruction
+  :update-atis
+  [engine [_ letter]]
+  (if (= (get-in engine [:weather :atis])
+         letter)
+    (>evt [:help/reward "Thank you for handling the updated ATIS!"])
+    (>evt [:help/warning (str "Information " letter " is NOT current!")]))
+  engine)
+
+(defmethod dispatch-global-instruction
+  :default
+  [engine [instruction]]
+  (println "TODO: Unhandled global instruction: " instruction)
+  engine)

--- a/src/main/atc/engine/global.cljs
+++ b/src/main/atc/engine/global.cljs
@@ -7,6 +7,8 @@
 (defmethod dispatch-global-instruction
   :update-atis
   [engine [_ letter]]
+  ; TODO This should probably reward/deduct points.
+  ; TODO We should check if they've already done this or not
   (if (= (get-in engine [:weather :atis])
          letter)
     (>evt [:help/reward "Thank you for handling the updated ATIS!"])

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -499,6 +499,15 @@
                    :text msg}]})))
 
 (reg-event-fx
+  :help/reward
+  [trim-v]
+  (fn [_ message]
+    {:dispatch [:radio-history/push
+                {:speaker :system/reward
+                 :text message}]}))
+
+
+(reg-event-fx
   :help/warning
   [trim-v]
   (fn [_ message]
@@ -514,4 +523,5 @@
   (dispatch [:weather/refresh])
 
   (dispatch [::voice-handle-text "delta twenty two turn right heading one eight zero"])
-  (dispatch [::voice-handle-text "delta twenty two contact center point eight good day"]))
+  (dispatch [::voice-handle-text "delta twenty two contact center point eight good day"])
+  (dispatch [::voice-handle-text "attention all aircraft information alpha is current"]))

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -21,7 +21,8 @@
 ; ======= Engine data injection ===========================
 
 (def injected-subscriptions
-  [[:game/airport-runway-ids]
+  [[:game/active-runways]
+   [:game/airport-runway-ids]
    [:game/navaids-by-id]])
 
 (def engine-injections

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -10,7 +10,7 @@
    [atc.util.local-storage :as local-storage]
    [atc.util.spec :refer [pre-validate]]
    [atc.weather.fx :as weather-fx]
-   [atc.weather.spec :refer [weather-spec]]
+   [atc.weather.spec :refer [default-wx weather-spec]]
    [clojure.string :as str]
    [re-frame.core :refer [->interceptor dispatch get-coeffect get-effect
                           inject-cofx path reg-event-db reg-event-fx trim-v unwrap]]
@@ -429,6 +429,12 @@
   :weather/refresh
   (fn [{:keys [db]}]
     {::weather-fx/fetch (name (get-in db [:game-options :airport-id]))}))
+
+(reg-event-fx
+  :weather/failed
+  [trim-v]
+  (fn [_ [airport-icao]]
+    {:dispatch [:weather/fetched airport-icao default-wx]}))
 
 (reg-event-db
   :weather/fetched

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -441,7 +441,7 @@
   (case code
     nil (String/fromCharCode
           (+ (.charCodeAt "A" 0)
-             (mod (floor (/ now 60000)) 25)))
+             (mod (floor (/ now 60000)) 26)))
     "Z" "A"
     (String/fromCharCode (inc (.charCodeAt "B" 0)))))
 

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -422,6 +422,7 @@
   (fn [config updates]
     (merge config updates)))
 
+
 ; ======= Weather =========================================
 
 (reg-event-fx

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -190,7 +190,10 @@
              (assoc :last-game (select-keys db [:engine :engine-config
                                                 :game-events :game-history
                                                 :radio-history])))
-     :dispatch [:voice/stop!]}))
+     :fx [[:dispatch [:voice/stop!]]
+
+          ; Cancel all deferrables
+          [:defer/cancel :all]]}))
 
 (reg-event-fx
   :game/set-time-scale
@@ -463,7 +466,9 @@
     (let [current-airport (get-in db [:game-options :airport-id])]
       {:db (cond-> db
              (= airport-icao (name current-airport))
-             (update-weather now wx))})))
+             (update-weather now wx))
+       :fx [[:defer {:ms (* 10 60000) ; every 10 minutes
+                     :dispatch [:weather/refresh]}]]})))
 
 
 ; ======= "Help" functionality ============================

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -452,8 +452,8 @@
                             (get-in db [:engine :weather])
                             wx-keys))]
     (cond-> db
-      wx-changed? (update-in [:engine :weather :atis] increment-atis now)
-      true (assoc-in [:engine :weather] wx))))
+      true (assoc-in [:engine :weather] wx)
+      wx-changed? (update-in [:engine :weather :atis] increment-atis now))))
 
 (reg-event-fx
   :weather/fetched
@@ -461,9 +461,9 @@
   (fn [{now :now db :db} [airport-icao wx]]
     {:pre [(pre-validate weather-spec wx)]}
     (let [current-airport (get-in db [:game-options :airport-id])]
-      (cond-> db
-        (= airport-icao (name current-airport))
-        (update-weather now wx)))))
+      {:db (cond-> db
+             (= airport-icao (name current-airport))
+             (update-weather now wx))})))
 
 
 ; ======= "Help" functionality ============================

--- a/src/main/atc/game/traffic/model.cljs
+++ b/src/main/atc/game/traffic/model.cljs
@@ -16,7 +16,7 @@
 (def flight-spec
   (ds/spec
     {:name ::flight
-     :spec {:aircraft traffic-aircraft-spec
+     :spec {(ds/opt :aircraft) traffic-aircraft-spec
             :delay-to-next-s number?}}))
 
 (defprotocol ITraffic

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -38,19 +38,23 @@
        ; TODO Maybe depend on "difficulty"?
        :delay-to-next-s 240}))
 
-  (next-departure [_ {:keys [airport] runways :game/active-runways}]
-    (let [destination (pick-random
-                        random
-                        (-> airport :departure-routes keys))]
-      {:aircraft {:type :airline
-                  :airline (pick-random random (keys all-airlines))
-                  :flight-number (next-int random 20 9999)
-                  :destination destination
-                  :route (-> airport (get-in [:departure-routes destination]))
+  (next-departure [_ {:keys [airport]
+                      runways :game/active-runways}]
+    (if-not runways
+      {:delay-to-next-s 1}
 
-                  ; TODO Round-robin runway selection, if multiple available
-                  :runway (->> runways :departures first)
-                  :config configs/common-jet}
+      (let [destination (pick-random
+                          random
+                          (-> airport :departure-routes keys))]
+        {:aircraft {:type :airline
+                    :airline (pick-random random (keys all-airlines))
+                    :flight-number (next-int random 20 9999)
+                    :destination destination
+                    :route (-> airport (get-in [:departure-routes destination]))
 
-       ; TODO This should at least depend on the spawned aircraft's speed, etc. Maybe "difficulty"?
-       :delay-to-next-s 240})))
+                    ; TODO Round-robin runway selection, if multiple available
+                    :runway (->> runways :departures first)
+                    :config configs/common-jet}
+
+         ; TODO This should at least depend on the spawned aircraft's speed, etc. Maybe "difficulty"?
+         :delay-to-next-s 240}))))

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -38,7 +38,7 @@
        ; TODO Maybe depend on "difficulty"?
        :delay-to-next-s 240}))
 
-  (next-departure [_ {:keys [airport]}]
+  (next-departure [_ {:keys [airport] runways :game/active-runways}]
     (let [destination (pick-random
                         random
                         (-> airport :departure-routes keys))]
@@ -48,8 +48,8 @@
                   :destination destination
                   :route (-> airport (get-in [:departure-routes destination]))
 
-                  ; TODO weather; runway selection
-                  :runway (-> airport :runways first :start-id)
+                  ; TODO Round-robin runway selection, if multiple available
+                  :runway (->> runways :departures first)
                   :config configs/common-jet}
 
        ; TODO This should at least depend on the spawned aircraft's speed, etc. Maybe "difficulty"?

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -6,7 +6,7 @@
    [atc.engine.model :refer [spawn-aircraft]]
    [atc.game.traffic.model :refer [ITraffic next-arrival]]
    [atc.game.traffic.shared :refer [position-arriving-aircraft]]
-   [atc.util.seedable :refer [next-int pick-random]]))
+   [atc.util.seedable :refer [next-boolean next-int pick-random]]))
 
 (defrecord RandomTraffic [random]
   ITraffic
@@ -26,12 +26,17 @@
     (let [origin (pick-random
                    random
                    (-> airport :arrival-routes keys))
+
+          ; Will this aircraft get the weather before contacting approach?
+          will-get-weather? (next-boolean random)
+
           craft {:type :airline
                  :airline (pick-random random (keys all-airlines))
                  :flight-number (next-int random 20 9999)
                  :origin origin
                  :destination (:id airport)
                  :route (-> airport (get-in [:arrival-routes origin :route]))
+                 :behavior {:will-get-weather? will-get-weather?}
                  :config configs/common-jet}]
       {:aircraft (position-arriving-aircraft engine craft)
 

--- a/src/main/atc/radio.cljs
+++ b/src/main/atc/radio.cljs
@@ -2,6 +2,7 @@
   (:require
    [atc.data.airlines :refer [all-airlines]]
    [atc.util.numbers :refer [->int]]
+   [atc.voice.parsing.letters :refer [letter]]
    [atc.voice.parsing.numbers :as numbers]
    [clojure.set :refer [map-invert]]
    [com.rpl.specter :as s]))
@@ -36,6 +37,13 @@
   [[_ v]]
   ; TODO 040 might come in as the int 40
   (-> v str seq))
+
+(def ^:private letter->speakable
+  (map-invert letter))
+
+(defmethod process-speakable :letter
+ [[_ v]]
+ (letter->speakable v))
 
 (defmethod process-speakable :runway
   [[_ string]]

--- a/src/main/atc/radio_test.cljs
+++ b/src/main/atc/radio_test.cljs
@@ -7,7 +7,9 @@
   (testing "Convert speakable vector objects"
     (is (= "cleared approach runway 1 3 left"
            (->speakable [["cleared approach runway"
-                          [:runway "13L"]]]))))
+                          [:runway "13L"]]])))
+    (is (= "we have alpha"
+           (->speakable [["we have" [:letter "A"]]]))))
 
   (testing "Preserve maps"
     (is (= "2 4 0 delta 22"

--- a/src/main/atc/styles.cljs
+++ b/src/main/atc/styles.cljs
@@ -7,7 +7,8 @@
 (defglobal window-styles
   [":root" {:*background* theme/background
             :*background-secondary* theme/background-secondary
-            :*text* theme/text}]
+            :*text* theme/text
+            :*map-text* theme/map-label-opaque}]
 
   [:body {:margin 0
           :padding 0}]

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -207,16 +207,14 @@
 
 (reg-sub
   :game/weather
-  :<- [:engine]
+  :<- [::engine]
   :-> :weather)
 
 (defn active-runways [[airport weather]]
   ; Use the weather, Luke
   (let [select-runway (:runway-selection airport)]
     (when (and weather select-runway)
-      (select-runway weather))
-    {:arrivals [(-> airport :runways first :start-id)]
-     :departures [(-> airport :runways first :start-id)]}))
+      (select-runway weather))))
 
 (reg-sub
   :game/active-runways

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -1,5 +1,6 @@
 (ns atc.subs
   (:require
+   [atc.config :as config]
    [atc.data.airports :refer [runway->heading]]
    [atc.data.core :refer [local-xy]]
    [atc.engine.model :refer [v* vec3]]
@@ -8,8 +9,7 @@
    [atc.util.subs :refer [get-or-identity]]
    [clojure.math :refer [floor]]
    [clojure.string :as str]
-   [re-frame.core :refer [reg-sub]]
-   [atc.config :as config]))
+   [re-frame.core :refer [reg-sub]]))
 
 (reg-sub
   :page
@@ -204,6 +204,25 @@
                     (assoc :end-angle (runway->heading airport (:end-id rwy)))
                     (update :start-threshold local-xy airport)
                     (update :end-threshold local-xy airport)))))))
+
+(reg-sub
+  :game/weather
+  :<- [:engine]
+  :-> :weather)
+
+(defn active-runways [airport weather]
+  ; Use the weather, Luke
+  (let [select-runway (:runway-selection airport)]
+    (when (and weather select-runway)
+      (select-runway weather))
+    {:arrivals [(-> airport :runways first :start-id)]
+     :departures [(-> airport :runways first :start-id)]}))
+
+(reg-sub
+  :game/active-runways
+  :<- [:airport]
+  :<- [:game/weather]
+  :-> active-runways)
 
 (reg-sub
   :ui/tick

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -210,7 +210,7 @@
   :<- [:engine]
   :-> :weather)
 
-(defn active-runways [airport weather]
+(defn active-runways [[airport weather]]
   ; Use the weather, Luke
   (let [select-runway (:runway-selection airport)]
     (when (and weather select-runway)
@@ -220,7 +220,7 @@
 
 (reg-sub
   :game/active-runways
-  :<- [:airport]
+  :<- [:game/airport]
   :<- [:game/weather]
   :-> active-runways)
 

--- a/src/main/atc/util/fetch.cljs
+++ b/src/main/atc/util/fetch.cljs
@@ -1,0 +1,18 @@
+(ns atc.util.fetch
+  (:require
+   [applied-science.js-interop :as j]
+   [promesa.core :as p]))
+
+(defn- fetch-with-timeout-impl [response-type url]
+  (p/let [controller (js/AbortController.)
+          timeout-ms 4500
+          timeout-timer (js/setTimeout #(.abort controller) timeout-ms)
+          response (js/fetch url #js {:signal (j/get controller :signal)})
+          result (j/call response response-type)]
+    (js/clearTimeout timeout-timer)
+    result))
+
+(def fetch-with-timeout
+  (if (j/get js/window :AbortController)
+    fetch-with-timeout-impl
+    js/fetch))

--- a/src/main/atc/util/numbers.cljc
+++ b/src/main/atc/util/numbers.cljc
@@ -1,10 +1,11 @@
 (ns atc.util.numbers
   (:require
-   [clojure.math :refer [floor]]))
+   [clojure.math :refer [floor]]
+   #? (:clj [clojure.string :as str])))
 
 (defn ->int [^String v]
   #? (:cljs (js/parseInt v 10)
-      :clj (Integer/parseInt v)))
+      :clj (Integer/parseInt (str/replace v #"[^0-9]+" ""))))
 
 (defn round-to-hundreds [n]
   (-> n

--- a/src/main/atc/util/seedable.cljc
+++ b/src/main/atc/util/seedable.cljc
@@ -31,6 +31,9 @@
           (seq values))
         idx))))
 
+(defn next-boolean [random]
+  (>= (next-double random) 0.5))
+
 (defn create-random
   ([] (create-random #?(:cljs (js/Date.now)
                         :clj (System/currentTimeMiillis))))

--- a/src/main/atc/util/spec.cljc
+++ b/src/main/atc/util/spec.cljc
@@ -11,3 +11,14 @@
       (let [explanation (s/explain-str spec value)]
         (println "Spec check failed: " explanation)
         false))))
+
+(defn validate-spec
+  "Throw an exception if db doesn't have a valid spec."
+  [spec value]
+  (if (s/valid? spec value)
+    value
+    (do
+      (tap> value)
+      (let [explanation (s/explain-str spec value)]
+        (throw (ex-info (str "Spec check failed: " explanation)
+                        {:value value}))))))

--- a/src/main/atc/util/spec.cljc
+++ b/src/main/atc/util/spec.cljc
@@ -11,14 +11,3 @@
       (let [explanation (s/explain-str spec value)]
         (println "Spec check failed: " explanation)
         false))))
-
-(defn validate-spec
-  "Throw an exception if db doesn't have a valid spec."
-  [spec value]
-  (if (s/valid? spec value)
-    value
-    (do
-      (tap> value)
-      (let [explanation (s/explain-str spec value)]
-        (throw (ex-info (str "Spec check failed: " explanation)
-                        {:value value}))))))

--- a/src/main/atc/views/game.cljs
+++ b/src/main/atc/views/game.cljs
@@ -2,6 +2,7 @@
   (:require
    ["@inlet/react-pixi" :as px]
    [archetype.util :refer [<sub]]
+   [archetype.views.error-boundary :refer [error-boundary]]
    [atc.events :as events]
    [atc.styles :refer [full-screen]] ; [atc.theme :as theme]
    [atc.theme :as theme]
@@ -123,11 +124,12 @@
       [:div (game-container-attrs)
        [game]
 
-       [:div (game-controls-container-attrs {:paused? paused?})
-        [game-controls]]
+       [error-boundary
+        [:div (game-controls-container-attrs {:paused? paused?})
+         [game-controls]]
 
-       [:div (system-status-container-attrs {:paused? paused?})
-        [system-status]]
+        [:div (system-status-container-attrs {:paused? paused?})
+         [system-status]]]
 
        (when paused?
          [pause-screen/view])])))

--- a/src/main/atc/views/game.cljs
+++ b/src/main/atc/views/game.cljs
@@ -2,9 +2,8 @@
   (:require
    ["@inlet/react-pixi" :as px]
    [archetype.util :refer [<sub]]
-   [archetype.views.error-boundary :refer [error-boundary]]
    [atc.events :as events]
-   [atc.styles :refer [full-screen]] ; [atc.theme :as theme]
+   [atc.styles :refer [full-screen]]
    [atc.theme :as theme]
    [atc.views.game-setup :as game-setup]
    [atc.views.game.controls :refer [game-controls]]
@@ -124,12 +123,11 @@
       [:div (game-container-attrs)
        [game]
 
-       [error-boundary
-        [:div (game-controls-container-attrs {:paused? paused?})
-         [game-controls]]
+       [:div (game-controls-container-attrs {:paused? paused?})
+        [game-controls]]
 
-        [:div (system-status-container-attrs {:paused? paused?})
-         [system-status]]]
+       [:div (system-status-container-attrs {:paused? paused?})
+        [system-status]]
 
        (when paused?
          [pause-screen/view])])))

--- a/src/main/atc/views/game.cljs
+++ b/src/main/atc/views/game.cljs
@@ -14,6 +14,7 @@
    [atc.views.game.graphics.range-rings :refer [range-rings]]
    [atc.views.game.graphics.runway :as runway]
    [atc.views.game.stage :refer [stage]]
+   [atc.views.game.system-status :refer [system-status]]
    [atc.views.game.viewport :refer [viewport]]
    [atc.views.pause-screen :as pause-screen]
    [reagent.core :as r]
@@ -25,6 +26,12 @@
 (defattrs game-controls-container-attrs [{:keys [paused?]}]
   {:position :absolute
    :bottom 0
+   :left 0
+   :visibility (when paused? :hidden)})
+
+(defattrs system-status-container-attrs [{:keys [paused?]}]
+  {:position :absolute
+   :top 0
    :left 0
    :visibility (when paused? :hidden)})
 
@@ -118,6 +125,9 @@
 
        [:div (game-controls-container-attrs {:paused? paused?})
         [game-controls]]
+
+       [:div (system-status-container-attrs {:paused? paused?})
+        [system-status]]
 
        (when paused?
          [pause-screen/view])])))

--- a/src/main/atc/views/game/system_status.cljs
+++ b/src/main/atc/views/game/system_status.cljs
@@ -21,10 +21,11 @@
    (when-let [weather (<sub [:game/weather])]
      [:<>
       [:div.row [:span (:date-time weather)] [:span (:altimeter weather)]]
+
       ; TODO Flow (?)
 
       [:div.row
-       [:span "B"] ; TODO atis code
+       [:span (:atis weather)]
        [:span (str (:wind-heading weather)
                    "/"
                    (:wind-kts weather))]

--- a/src/main/atc/views/game/system_status.cljs
+++ b/src/main/atc/views/game/system_status.cljs
@@ -1,0 +1,28 @@
+(ns atc.views.game.system-status
+  (:require
+   [archetype.util :refer [<sub]]
+   [garden.units :refer [px]]
+   [spade.core :refer [defattrs]]))
+
+(defattrs system-status-attrs []
+  {:color :*map-text*
+   :font-family :monospace
+   :font-weight 600
+   :position :absolute
+   :padding (px 32)}
+
+  [:.row {:display :flex
+          :gap (px 8)
+          :flex-direction :row}])
+
+(defn system-status []
+  [:div (system-status-attrs)
+   (when-let [weather (<sub [:game/weather])]
+     ; TODO Time, altimeter
+     ; TODO Flow (?)
+     ; TODO ATIS code, wind direction/speed, (runways below)
+     [:div (str weather)])
+
+   (when-let [{:keys [arrivals departures]} (<sub [:game/active-runways])]
+     ; TODO
+     [:div.row "RWYS " (into [:span] arrivals) " / " (into [:span] departures)])])

--- a/src/main/atc/views/game/system_status.cljs
+++ b/src/main/atc/views/game/system_status.cljs
@@ -13,16 +13,25 @@
 
   [:.row {:display :flex
           :gap (px 8)
-          :flex-direction :row}])
+          :flex-direction :row
+          :width (px 800)}])
 
 (defn system-status []
   [:div (system-status-attrs)
    (when-let [weather (<sub [:game/weather])]
-     ; TODO Time, altimeter
-     ; TODO Flow (?)
-     ; TODO ATIS code, wind direction/speed, (runways below)
-     [:div (str weather)])
+     [:<>
+      [:div.row [:span (:date-time weather)] [:span (:altimeter weather)]]
+      ; TODO Flow (?)
 
-   (when-let [{:keys [arrivals departures]} (<sub [:game/active-runways])]
-     ; TODO
-     [:div.row "RWYS " (into [:span] arrivals) " / " (into [:span] departures)])])
+      [:div.row
+       [:span "B"] ; TODO atis code
+       [:span (str (:wind-heading weather)
+                   "/"
+                   (:wind-kts weather))]
+
+       (when-let [{:keys [arrivals departures]} (<sub [:game/active-runways])]
+         [:<>
+          [:span "RWYS"]
+          (into [:span] arrivals)
+          " / "
+          (into [:span] departures)])]])])

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -35,31 +35,52 @@
   [:other-position :pleasantry :frequency :navaid :altitude
    :approach-type :runway :heading :letter])
 
+(defrules ^:private global-command-rules
+  ["atis-update = attention-all <'atis'>? <'information'>? letter <'is current'>"]
+
+  [:attention-all :letter])
+
 (defalternates-expr ^:hide-tag instruction
   (->> instructions-rules
        :grammar
        keys))
 
-(defrules ^:private core-rules
-  ["command = callsign instruction+"
+(defalternates-expr global-command
+  (->> global-command-rules
+       :grammar
+       keys))
 
+(defrules ^:private core-rules
+  ["command = aircraft-command | global-command"
+
+   "aircraft-command = callsign instruction+"
+
+   "<attention-all> = <'attention'> <'all'>? <'aircraft'>? <'on frequency'>?"
    "approach-type = 'i l s' | 'r nav' | 'visual'"
    "runway = number-sequence (letter | 'left' | 'right' | 'north' | 'south')?"]
   {:other-position other-position
    :pleasantry pleasantry
    :callsign nil
    :instruction instruction
+   :global-command global-command
    :number-sequence nil
    :letter nil})
 
 (def rules (merge-with merge
                        core-rules
-                       instructions-rules))
+                       instructions-rules
+                       global-command-rules))
 
 (def transformers
-  {:command (fn [callsign & instructions]
-              {:callsign (second callsign)
-               :instructions instructions})
+  {:command (fn [v] v)
+
+   :aircraft-command (fn [callsign & instructions]
+                       {:callsign (second callsign)
+                        :instructions instructions})
+
+   :global-command (fn [command]
+                     {:global? true
+                      :instructions [command]})
 
    :contact-other (fn [other-position & etc]
                     [:contact-other

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -28,9 +28,12 @@
 
    "direct = <'proceed direct'> navaid"
 
-   "steer = (<'fly'> | 'turn right' | 'turn left') <'heading'> heading"]
+   "steer = (<'fly'> | 'turn right' | 'turn left') <'heading'> heading"
 
-  [:other-position :pleasantry :frequency :navaid :altitude :approach-type :runway :heading])
+   "verify-atis = (<'verify you have'> <'information'>? letter) | (<'information'> letter <'is current'>)"]
+
+  [:other-position :pleasantry :frequency :navaid :altitude
+   :approach-type :runway :heading :letter])
 
 (defalternates-expr ^:hide-tag instruction
   (->> instructions-rules

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -114,3 +114,12 @@
     (is (= [[:cleared-approach :visual "30L"]]
            (find-instructions
              "piper one cleared visual approach runway tree zero left")))))
+
+(deftest verify-atis-test
+  (testing "Request to verify ATIS"
+    (is (= [[:verify-atis "A"]]
+           (find-instructions
+             "piper one verify you have information alpha")))
+    (is (= [[:verify-atis "A"]]
+           (find-instructions
+             "piper one information alpha is current")))))

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -123,3 +123,10 @@
     (is (= [[:verify-atis "A"]]
            (find-instructions
              "piper one information alpha is current")))))
+
+(deftest global-command-test
+  (testing "Notify ATIS changed"
+    (is (= {:global? true
+            :instructions [[:atis-update "A"]]}
+           (find-command
+             "attention all aircraft information alpha is current")))))

--- a/src/main/atc/weather/api.cljs
+++ b/src/main/atc/weather/api.cljs
@@ -1,0 +1,14 @@
+(ns atc.weather.api
+  (:require
+   [atc.weather.metar :as metar]
+   [promesa.core :as p]))
+
+(def ^:private metar-endpoint
+  "https://metar.vatsim.net/metar.php?id=")
+
+(defn fetch-metar-text [airport-icao]
+  (js/fetch (str metar-endpoint airport-icao)))
+
+(defn fetch-weather [airport-icao]
+  (p/let [text (fetch-metar-text airport-icao)]
+    (metar/parse-text text)))

--- a/src/main/atc/weather/api.cljs
+++ b/src/main/atc/weather/api.cljs
@@ -1,5 +1,6 @@
 (ns atc.weather.api
   (:require
+   [atc.util.fetch :refer [fetch-with-timeout]]
    [atc.weather.metar :as metar]
    [promesa.core :as p]))
 
@@ -7,7 +8,7 @@
   "https://metar.vatsim.net/metar.php?id=")
 
 (defn fetch-metar-text [airport-icao]
-  (js/fetch (str metar-endpoint airport-icao)))
+  (fetch-with-timeout :text (str metar-endpoint airport-icao)))
 
 (defn fetch-weather [airport-icao]
   (p/let [text (fetch-metar-text airport-icao)]

--- a/src/main/atc/weather/api.cljs
+++ b/src/main/atc/weather/api.cljs
@@ -12,4 +12,6 @@
 
 (defn fetch-weather [airport-icao]
   (p/let [text (fetch-metar-text airport-icao)]
-    (metar/parse-text text)))
+    (or (metar/parse-text text)
+        (throw (ex-info "Failed to parse METAR" {:text text
+                                                 :icao airport-icao})))))

--- a/src/main/atc/weather/fx.cljs
+++ b/src/main/atc/weather/fx.cljs
@@ -1,0 +1,15 @@
+(ns atc.weather.fx
+  (:require
+   [archetype.util :refer [>evt]]
+   [atc.weather.api :as api]
+   [promesa.core :as p]
+   [re-frame.core :refer [reg-fx]]))
+
+(reg-fx
+  ::fetch
+  (fn [airport-icao]
+    (-> (p/let [wx (api/fetch-weather airport-icao)]
+          (>evt [:weather/fetched airport-icao wx]))
+        (p/catch (fn [e]
+                   ; TODO
+                   (println e))))))

--- a/src/main/atc/weather/fx.cljs
+++ b/src/main/atc/weather/fx.cljs
@@ -10,8 +10,10 @@
   (fn [airport-icao]
     (-> (p/let [wx (api/fetch-weather airport-icao)]
           (println "[wx] Fetched @" airport-icao ": " wx)
-          (>evt [:weather/fetched airport-icao wx]))
+          (>evt [:weather/failed airport-icao]))
         (p/catch (fn [e]
                    (js/console.error "[wx] Failed to fetch @"
                                      airport-icao e)
+                   (when-some [text (:text (ex-data e))]
+                     (js/console.error "[wx]  - METAR text: " text))
                    (>evt [:weather/failed airport-icao]))))))

--- a/src/main/atc/weather/fx.cljs
+++ b/src/main/atc/weather/fx.cljs
@@ -11,5 +11,6 @@
     (-> (p/let [wx (api/fetch-weather airport-icao)]
           (>evt [:weather/fetched airport-icao wx]))
         (p/catch (fn [e]
-                   ; TODO
-                   (println e))))))
+                   (js/console.error "[wx] Failed to fetch @"
+                                     airport-icao e)
+                   (>evt [:weather/failed airport-icao]))))))

--- a/src/main/atc/weather/fx.cljs
+++ b/src/main/atc/weather/fx.cljs
@@ -9,6 +9,7 @@
   ::fetch
   (fn [airport-icao]
     (-> (p/let [wx (api/fetch-weather airport-icao)]
+          (println "[wx] Fetched @" airport-icao ": " wx)
           (>evt [:weather/fetched airport-icao wx]))
         (p/catch (fn [e]
                    (js/console.error "[wx] Failed to fetch @"

--- a/src/main/atc/weather/metar.cljc
+++ b/src/main/atc/weather/metar.cljc
@@ -5,9 +5,9 @@
    [instaparse.core :as insta :refer-macros [defparser]]))
 
 (defparser ^:private metar-parser
-  "<metar> = airport time wind visibility-sm clouds temp-dewpoint altimeter
+  "<metar> = airport date-time wind visibility-sm clouds temp-dewpoint altimeter
    airport = letter+
-   time = numbers <'Z'>
+   date-time = number+ 'Z'
    wind = wind-direction wind-kts (<'G'> numbers)? <'KT'>
    clouds = cloud*
    temp-dewpoint = temperature <'/'> temperature
@@ -28,7 +28,9 @@
   (->int (str/join numbers)))
 
 (def ^:private transformers
-  {:temperature (fn
+  {:date-time (fn [& parts]
+                [:date-time (str/join parts)])
+   :temperature (fn
                   ([temp] temp)
                   ([_minus temp]
                    (- temp)))
@@ -45,9 +47,10 @@
                    (map (fn [[k & v]]
                           [k v]))
                    (into {}))
-        {:keys [altimeter wind visibility-sm temp-dewpoint]} parts]
+        {:keys [altimeter date-time temp-dewpoint wind visibility-sm]} parts]
     {:altimeter (let [[a b c d] altimeter]
                   (str a b "." c d))
+     :date-time (first date-time)
      :dewpoint-c (second temp-dewpoint)
      :temperature-c (first temp-dewpoint)
      :visibility-sm (first visibility-sm)

--- a/src/main/atc/weather/metar.cljc
+++ b/src/main/atc/weather/metar.cljc
@@ -1,0 +1,6 @@
+(ns atc.weather.metar)
+
+(defn parse-text [raw-metar]
+  ; TODO
+  {:wind-heading 90
+   :wind-kts 0})

--- a/src/main/atc/weather/metar.cljc
+++ b/src/main/atc/weather/metar.cljc
@@ -17,7 +17,7 @@
    temperature = 'M'? numbers
    wind-direction = number number number
    wind-kts = number number
-   visibility-sm = numbers <'SM'>
+   visibility-sm = numbers (<'/'> numbers)? <'SM'>
 
    <letter> = #'[A-Z]'
    numbers = number+
@@ -34,6 +34,10 @@
                   ([temp] temp)
                   ([_minus temp]
                    (- temp)))
+   :visibility-sm (fn visibility-sm
+                    ([n] (visibility-sm n 1))
+                    ([numer denom]
+                     [:visibility-sm (/ numer denom)]))
    :wind-direction parse-numbers
    :wind-kts parse-numbers
    :numbers parse-numbers})

--- a/src/main/atc/weather/metar.cljc
+++ b/src/main/atc/weather/metar.cljc
@@ -9,11 +9,18 @@
    airport = letter+
    date-time = number+ 'Z'
    wind = wind-direction wind-kts (<'G'> numbers)? <'KT'>
-   clouds = cloud*
+   clouds = (cloud | weather)*
    temp-dewpoint = temperature <'/'> temperature
    altimeter = <'A'> number number number number
 
+   (*
+   Clouds are FEW020.
+   The -/+ before Weather indicates light/heavy. Omitting it is 'moderate',
+   but that collides with our lazy definition for Clouds so it's left off.
+   *)
    cloud = #'\\w+'
+   weather = #'[-+][A-Z]+'
+
    temperature = 'M'? numbers
    wind-direction = number number number
    wind-kts = number number
@@ -52,6 +59,7 @@
                           [k v]))
                    (into {}))
         {:keys [altimeter date-time temp-dewpoint wind visibility-sm]} parts]
+    (println parts)
     {:altimeter (let [[a b c d] altimeter]
                   (str a b "." c d))
      :date-time (first date-time)

--- a/src/main/atc/weather/metar.cljc
+++ b/src/main/atc/weather/metar.cljc
@@ -59,12 +59,13 @@
                           [k v]))
                    (into {}))
         {:keys [altimeter date-time temp-dewpoint wind visibility-sm]} parts]
-    (println parts)
-    {:altimeter (let [[a b c d] altimeter]
-                  (str a b "." c d))
-     :date-time (first date-time)
-     :dewpoint-c (second temp-dewpoint)
-     :temperature-c (first temp-dewpoint)
-     :visibility-sm (first visibility-sm)
-     :wind-heading (first wind)
-     :wind-kts (second wind)}))
+    ; We *at least* need wind to have been parsed correctly...
+    (when (seq wind)
+      {:altimeter (let [[a b c d] altimeter]
+                    (str a b "." c d))
+       :date-time (first date-time)
+       :dewpoint-c (second temp-dewpoint)
+       :temperature-c (first temp-dewpoint)
+       :visibility-sm (first visibility-sm)
+       :wind-heading (first wind)
+       :wind-kts (second wind)})))

--- a/src/main/atc/weather/metar.cljc
+++ b/src/main/atc/weather/metar.cljc
@@ -1,6 +1,55 @@
-(ns atc.weather.metar)
+(ns atc.weather.metar
+  (:require
+   [atc.util.numbers :refer [->int]]
+   [clojure.string :as str]
+   [instaparse.core :as insta :refer-macros [defparser]]))
+
+(defparser ^:private metar-parser
+  "<metar> = airport time wind visibility-sm clouds temp-dewpoint altimeter
+   airport = letter+
+   time = numbers <'Z'>
+   wind = wind-direction wind-kts (<'G'> numbers)? <'KT'>
+   clouds = cloud*
+   temp-dewpoint = temperature <'/'> temperature
+   altimeter = <'A'> number number number number
+
+   cloud = #'\\w+'
+   temperature = 'M'? numbers
+   wind-direction = number number number
+   wind-kts = number number
+   visibility-sm = numbers <'SM'>
+
+   <letter> = #'[A-Z]'
+   numbers = number+
+   <number> = #'[0-9]'"
+  :auto-whitespace :standard)
+
+(defn- parse-numbers [& numbers]
+  (->int (str/join numbers)))
+
+(def ^:private transformers
+  {:temperature (fn
+                  ([temp] temp)
+                  ([_minus temp]
+                   (- temp)))
+   :wind-direction parse-numbers
+   :wind-kts parse-numbers
+   :numbers parse-numbers})
 
 (defn parse-text [raw-metar]
-  ; TODO
-  {:wind-heading 90
-   :wind-kts 0})
+  (let [parts (->> (metar-parser raw-metar :partial true)
+
+                   ; NOTE: clj-kondo seems confused but this fn definitely exists!
+                   #_{:clj-kondo/ignore [:unresolved-var]}
+                   (insta/transform transformers)
+                   (map (fn [[k & v]]
+                          [k v]))
+                   (into {}))
+        {:keys [altimeter wind visibility-sm temp-dewpoint]} parts]
+    {:altimeter (let [[a b c d] altimeter]
+                  (str a b "." c d))
+     :dewpoint-c (second temp-dewpoint)
+     :temperature-c (first temp-dewpoint)
+     :visibility-sm (first visibility-sm)
+     :wind-heading (first wind)
+     :wind-kts (second wind)}))

--- a/src/main/atc/weather/metar_test.cljs
+++ b/src/main/atc/weather/metar_test.cljs
@@ -1,0 +1,25 @@
+(ns atc.weather.metar-test
+  (:require
+   [atc.weather.metar :as metar]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest parse-text-test
+  (testing "Simple wind test"
+    (is (= {:altimeter "30.26"
+            :dewpoint-c -13
+            :temperature-c 21
+            :visibility-sm 10
+            :wind-heading 150
+            :wind-kts 8}
+
+           (metar/parse-text
+             "KJFK 012151Z 15008KT 10SM FEW250 21/M13 A3026 RMK AO2 SLP248 T02060128"))))
+
+  (testing "Gusting wind test"
+    (is (= {:wind-heading 150
+            :wind-kts 8}
+
+           (->
+             "KJFK 012151Z 15008G20KT 10SM FEW250 21/M13 A3026 RMK AO2 SLP248 T02060128"
+             (metar/parse-text)
+             (select-keys [:wind-heading :wind-kts]))))))

--- a/src/main/atc/weather/metar_test.cljs
+++ b/src/main/atc/weather/metar_test.cljs
@@ -31,4 +31,12 @@
            (->
              "KJFK 012151Z 15008G20KT 1/2SM FEW250 21/M13 A3026 RMK AO2 SLP248 T02060128"
              (metar/parse-text)
+             (select-keys [:visibility-sm])))))
+
+  (testing "Thunderstorm"
+    (is (= {:visibility-sm 10}
+
+           (->
+             "KJFK 101504Z 20011KT 10SM -TSRA BKN009 BKN036CB OVC045 25/24 A3013 RMK AO2 TSE1458B03 OCNL LTGICCG OHD-SW TS OHD-SW MOV NE P0000 T02500239 $"
+             (metar/parse-text)
              (select-keys [:visibility-sm]))))))

--- a/src/main/atc/weather/metar_test.cljs
+++ b/src/main/atc/weather/metar_test.cljs
@@ -4,7 +4,7 @@
    [clojure.test :refer [deftest is testing]]))
 
 (deftest parse-text-test
-  (testing "Simple wind test"
+  (testing "Simple wind"
     (is (= {:altimeter "30.26"
             :date-time "012151Z"
             :dewpoint-c -13
@@ -16,11 +16,19 @@
            (metar/parse-text
              "KJFK 012151Z 15008KT 10SM FEW250 21/M13 A3026 RMK AO2 SLP248 T02060128"))))
 
-  (testing "Gusting wind test"
+  (testing "Gusting wind"
     (is (= {:wind-heading 150
             :wind-kts 8}
 
            (->
              "KJFK 012151Z 15008G20KT 10SM FEW250 21/M13 A3026 RMK AO2 SLP248 T02060128"
              (metar/parse-text)
-             (select-keys [:wind-heading :wind-kts]))))))
+             (select-keys [:wind-heading :wind-kts])))))
+
+  (testing "Low visibility"
+    (is (= {:visibility-sm (/ 1 2)}
+
+           (->
+             "KJFK 012151Z 15008G20KT 1/2SM FEW250 21/M13 A3026 RMK AO2 SLP248 T02060128"
+             (metar/parse-text)
+             (select-keys [:visibility-sm]))))))

--- a/src/main/atc/weather/metar_test.cljs
+++ b/src/main/atc/weather/metar_test.cljs
@@ -6,6 +6,7 @@
 (deftest parse-text-test
   (testing "Simple wind test"
     (is (= {:altimeter "30.26"
+            :date-time "012151Z"
             :dewpoint-c -13
             :temperature-c 21
             :visibility-sm 10

--- a/src/main/atc/weather/spec.cljc
+++ b/src/main/atc/weather/spec.cljc
@@ -5,10 +5,14 @@
 (def weather-spec
   (ds/spec
     {:name ::weather
-     :spec {:wind-heading number?
+     :spec {:altimeter string?
+            :date-time string?
+            :wind-heading number?
             :wind-kts number?}}))
 
 ; TODO: Should this belong to the airport?
 (def default-wx
-  {:wind-heading 300
+  {:altimeter "30.26"
+   :date-time "012151Z"
+   :wind-heading 300
    :wind-kts 4})

--- a/src/main/atc/weather/spec.cljc
+++ b/src/main/atc/weather/spec.cljc
@@ -7,3 +7,8 @@
     {:name ::weather
      :spec {:wind-heading number?
             :wind-kts number?}}))
+
+; TODO: Should this belong to the airport?
+(def default-wx
+  {:wind-heading 300
+   :wind-kts 4})

--- a/src/main/atc/weather/spec.cljc
+++ b/src/main/atc/weather/spec.cljc
@@ -1,0 +1,9 @@
+(ns atc.weather.spec
+  (:require
+   [spec-tools.data-spec :as ds]))
+
+(def weather-spec
+  (ds/spec
+    {:name ::weather
+     :spec {:wind-heading number?
+            :wind-kts number?}}))


### PR DESCRIPTION
Closes #31 

We currently use Vatsim's METAR service to fetch the weather every 10 minutes. This weather is used to power a very simplified (IE: not based on real-world SOPs, because I couldn't find a good source to generate them from) runway selection.

Weather information, including a randomly-generated ATIS code, the selected runways, altimeter, and wind, are rendered in a "system status" area roughly inspired by the same in ATC Pro. The ATIS code is rotated automatically when the wind direction or altimeter setting change.

You can notify all aircraft on frequency about updated ATIS codes, and ask aircraft to verify the ATIS they have. Generated arrivals will have a random chance of calling in "with the weather."

We don't yet record points for prompting aircraft to get the weather (or remove points for failing to do so) but we do keep some basic state around so we *could*. We similarly don't yet track the last "announced" ATIS to be able to warn you if you announce an ATIS that hasn't changed, for example.

<img width="1340" alt="Screenshot 2023-09-10 at 2 58 35 PM" src="https://github.com/dhleong/cljs-atc/assets/816150/95822d25-58af-4a5e-a289-5b04fddf15c1">

