### PR TITLE
Add special voice handling for the word "ATIS"

### DIFF
--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -9,6 +9,7 @@
    [atc.util.interceptors :refer [persist-key]]
    [atc.util.local-storage :as local-storage]
    [atc.util.spec :refer [pre-validate]]
+   [atc.voice.pretty :refer [cleanup-spoken-text]]
    [atc.weather.fx :as weather-fx]
    [atc.weather.spec :refer [default-wx weather-spec]]
    [clojure.math :refer [floor]]
@@ -387,7 +388,7 @@
              (update :radio-history conj {:speaker "CTR" ; TODO get this from :engine
                                           :freq 127.1 ; TODO this, too
                                           :timestamp now
-                                          :text full-input
+                                          :text (cleanup-spoken-text full-input)
                                           :self? true}))
      :voice/process {:machine (:parsing-machine (:engine db))
                      :input full-input}}))

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -7,6 +7,7 @@
    [atc.structures.rolling-history :refer [most-recent-n]]
    [atc.subs-util :refer [navaids-by-id]]
    [atc.util.subs :refer [get-or-identity]]
+   [atc.voice.pretty :refer [cleanup-spoken-text]]
    [clojure.math :refer [floor]]
    [clojure.string :as str]
    [re-frame.core :refer [reg-sub]]))
@@ -41,9 +42,10 @@
   :voice/partial
   :<- [::voice]
   (fn [voice]
-    (str/join " " (conj
-                    (:pending-results voice)
-                    (:partial-text voice)))))
+    (-> (str/join " " (conj
+                        (:pending-results voice)
+                        (:partial-text voice)))
+        (cleanup-spoken-text))))
 
 (reg-sub
   :voice/state

--- a/src/main/atc/voice/parsing/instructions.cljc
+++ b/src/main/atc/voice/parsing/instructions.cljc
@@ -30,15 +30,15 @@
 
    "steer = (<'fly'> | 'turn right' | 'turn left') <'heading'> heading"
 
-   "verify-atis = (<'verify you have'> <'information'>? letter) | (<'information'> letter <'is current'>)"]
+   "verify-atis = (<'verify you have'> atis? <'information'>? letter) | (atis? <'information'> letter <'is current'>)"]
 
   [:other-position :pleasantry :frequency :navaid :altitude
-   :approach-type :runway :heading :letter])
+   :approach-type :runway :heading :atis :letter])
 
 (defrules ^:private global-command-rules
-  ["atis-update = attention-all <'atis'>? <'information'>? letter <'is current'>"]
+  ["atis-update = attention-all atis? <'information'>? letter <'is current'>"]
 
-  [:attention-all :letter])
+  [:attention-all :atis :letter])
 
 (defalternates-expr ^:hide-tag instruction
   (->> instructions-rules
@@ -56,6 +56,7 @@
    "aircraft-command = callsign instruction+"
 
    "<attention-all> = <'attention'> <'all'>? <'aircraft'>? <'on frequency'>?"
+   "<atis> = <'ay tis'>"
    "approach-type = 'i l s' | 'r nav' | 'visual'"
    "runway = number-sequence (letter | 'left' | 'right' | 'north' | 'south')?"]
   {:other-position other-position

--- a/src/main/atc/voice/pretty.cljs
+++ b/src/main/atc/voice/pretty.cljs
@@ -1,0 +1,14 @@
+(ns atc.voice.pretty
+  (:require
+   [clojure.string :as str]))
+
+(def ^:private voice-partial-replacements
+  {"ay tis" "ATIS"})
+
+(def ^:private voice-partial-replacements-regex
+  (re-pattern
+    (str/join "|" (keys voice-partial-replacements))))
+
+(defn cleanup-spoken-text [text]
+  (-> text
+      (str/replace voice-partial-replacements-regex voice-partial-replacements)))

--- a/src/main/atc/voice/process_test.cljs
+++ b/src/main/atc/voice/process_test.cljs
@@ -129,4 +129,9 @@
     (is (= {:global? true
             :instructions [[:atis-update "A"]]}
            (find-command
-             "attention all aircraft information alpha is current")))))
+             "attention all aircraft information alpha is current")))
+
+    (is (= {:global? true
+            :instructions [[:atis-update "A"]]}
+           (find-command
+             "attention all aircraft ay tis information alpha is current")))))


### PR DESCRIPTION
Understandably, this is not in Vosk's dictionary. But "ay" and "tis"
are, which it is happy to provide when we say "ATIS." This change adds
the word "ATIS" as grammar referring to the phrase "ay tis," and cleans
cleans up the presentation of that text to appear as "ATIS" in the
history
