### PR TITLE
Add flight strip displays

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="darkreader-lock">
     <meta name="darkreader" content="disable-please">
     <title>cljs-atc</title>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
   </head>
   <body>
     <noscript>

--- a/src/main/atc/components/browser_window.cljs
+++ b/src/main/atc/components/browser_window.cljs
@@ -73,6 +73,10 @@
   (r/with-let [state (swap! windows mount-configured-window config)
                window (get-in state [config :window])]
 
+    (when-some [on-close (:on-close config)]
+      (println "SET onclose" on-close)
+      (set! (.-onunload window) on-close))
+
     (react-dom/createPortal
       (r/as-element [browser-window-root window children])
       (j/get-in window [:document :body]))

--- a/src/main/atc/components/browser_window.cljs
+++ b/src/main/atc/components/browser_window.cljs
@@ -1,0 +1,70 @@
+(ns atc.components.browser-window
+  (:require
+   ["react-dom" :as react-dom]
+   [applied-science.js-interop :as j]
+   [atc.styles :refer [window-styles]]
+   [clojure.string :as str]
+   [reagent.core :as r]
+   [spade.react :as spade-react]
+   [spade.runtime :as spade-runtime]))
+
+; NOTE: This is a hack! spade doesn't currently support automatically
+; rendering global styles into a style-container
+(defn- window-styles-mounter []
+  #_{:clj-kondo/ignore [:invalid-arity]} ; Kondo is wrong here...?
+  (spade-runtime/ensure-style!
+    :global
+    (meta #'window-styles)
+    (constantly "window-styles")
+    (constantly {:css window-styles})
+    nil)
+  [:<>])
+
+(defn- open-window [{:keys [window-name] :as opts}]
+  (js/window.open
+    ""
+    (str window-name)
+    (->> (reduce-kv
+           (fn [s k v]
+             (cond-> s
+               (not= k window-name)
+               (conj (str (name k) "=" v))))
+           []
+           opts)
+         (str/join ","))))
+
+(defn- browser-window-root [window children]
+  (into [spade-react/with-dom (j/get-in window [:document :head])
+         [window-styles-mounter]]
+        children))
+
+; NOTE: If we don't track the window externally to the browser component,
+; the window will get destroyed and reopened every time we hot swap
+(defonce ^:private windows (atom {}))
+
+(defn- mount-configured-window [state config]
+  (letfn [(closed? [w]
+            (or (nil? w)
+                (j/get w :closed)))]
+    (cond-> state
+      (closed? (get-in state [config :window]))
+      (assoc config {:window (open-window config)})
+
+      true
+      (update-in [config :mounted] inc))))
+
+(defn- unmount-configured-window [state config]
+  (update-in state [config :mounted] dec))
+
+(defn browser-window [config & children]
+  (r/with-let [state (swap! windows mount-configured-window config)
+               window (get-in state [config :window])]
+
+    (react-dom/createPortal
+      (r/as-element [browser-window-root window children])
+      (j/get-in window [:document :body]))
+
+    (finally
+      (let [state (swap! windows unmount-configured-window config)]
+        (when (= 0 (get-in state [config :mounted]))
+          (.close window))))))

--- a/src/main/atc/components/browser_window.cljs
+++ b/src/main/atc/components/browser_window.cljs
@@ -21,17 +21,30 @@
   [:<>])
 
 (defn- open-window [{:keys [window-name] :as opts}]
-  (js/window.open
-    ""
-    (str window-name)
-    (->> (reduce-kv
-           (fn [s k v]
-             (cond-> s
-               (not= k window-name)
-               (conj (str (name k) "=" v))))
-           []
-           opts)
-         (str/join ","))))
+  (let [w (js/window.open
+            ""
+            (str window-name)
+            (->> (reduce-kv
+                   (fn [s k v]
+                     (cond-> s
+                       (not= k window-name)
+                       (conj (str (name k) "=" v))))
+                   []
+                   opts)
+                 (str/join ",")))]
+
+    (.appendChild
+      (j/get-in w [:document :head])
+      (doto (j/call-in w [:document :createElement] "meta")
+        (.setAttribute "name" "darkreader-lock")))
+
+    (.appendChild
+      (j/get-in w [:document :head])
+      (doto (j/call-in w [:document :createElement] "meta")
+        (.setAttribute "name" "darkreader")
+        (.setAttribute "content" (str "window-" window-name))))
+
+    w))
 
 (defn- browser-window-root [window children]
   (into [spade-react/with-dom (j/get-in window [:document :head])

--- a/src/main/atc/components/browser_window.cljs
+++ b/src/main/atc/components/browser_window.cljs
@@ -4,6 +4,7 @@
    [applied-science.js-interop :as j]
    [atc.styles :refer [window-styles]]
    [clojure.string :as str]
+   [goog.dom :as gdom]
    [reagent.core :as r]
    [spade.react :as spade-react]
    [spade.runtime :as spade-runtime]))
@@ -33,11 +34,13 @@
                    opts)
                  (str/join ",")))]
 
-    (.appendChild
-      (j/get-in w [:document :head])
-      (doto (j/call-in w [:document :createElement] "meta")
-        (.setAttribute "name" "darkreader-lock")))
+    ; Just copy all of the parent doc's <head> tags into the child
+    (doseq [node (gdom/getChildren js/window.document.head)]
+      (.appendChild
+        (j/get-in w [:document :head])
+        (.cloneNode node)))
 
+    ; Plus a special one to ensure we disable darkreader on safari
     (.appendChild
       (j/get-in w [:document :head])
       (doto (j/call-in w [:document :createElement] "meta")

--- a/src/main/atc/components/browser_window.cljs
+++ b/src/main/atc/components/browser_window.cljs
@@ -74,7 +74,6 @@
                window (get-in state [config :window])]
 
     (when-some [on-close (:on-close config)]
-      (println "SET onclose" on-close)
       (set! (.-onunload window) on-close))
 
     (react-dom/createPortal

--- a/src/main/atc/components/icon.cljc
+++ b/src/main/atc/components/icon.cljc
@@ -1,0 +1,21 @@
+(ns atc.components.icon
+  (:require
+   [clojure.string :as str]))
+
+(defmacro icon
+  "A material design icon. `spec` is a keyword
+  that is usually the name of the icon, but
+  can also have .class like normal hiccup"
+  [spec & [opts]]
+  {:pre [(keyword? spec)]}
+  (let [spec (name spec)
+        class-offset (.indexOf spec ".")
+        classes (when (not= -1 class-offset)
+                  (subs spec class-offset))
+        icon-name (str/replace
+                    (if (not= -1 class-offset)
+                      (subs spec 0 class-offset)
+                      spec)
+                    #"-"
+                    "_")]
+    `[~(keyword (str "span.material-symbols-outlined" classes)) ~(or opts {}) ~icon-name]))

--- a/src/main/atc/components/icon.cljs
+++ b/src/main/atc/components/icon.cljs
@@ -1,0 +1,2 @@
+(ns atc.components.icon
+  (:require-macros [atc.components.icon]))

--- a/src/main/atc/components/icon_button.cljs
+++ b/src/main/atc/components/icon_button.cljs
@@ -1,0 +1,26 @@
+(ns atc.components.icon-button
+  (:require
+   [garden.units :refer [px]]
+   [spade.core :refer [defclass]]))
+
+(defn- prevent-default [f]
+  (when f
+    (fn [e]
+      (.preventDefault e)
+      (f e))))
+
+(defclass icon-button-class []
+  {:display :inline-flex
+   :align-items :center
+   :border-radius (px 4)
+   :color :*text*
+   :cursor :pointer
+   :justify-content :center
+   :padding (px 8)}
+  [:&:hover {:background-color :*background-hover*}])
+
+(defn icon-button [opts content]
+  [:a (-> opts
+          (assoc :class (icon-button-class))
+          (update :on-click prevent-default))
+   content])

--- a/src/main/atc/components/icon_button.cljs
+++ b/src/main/atc/components/icon_button.cljs
@@ -3,6 +3,13 @@
    [garden.units :refer [px]]
    [spade.core :refer [defclass]]))
 
+(defn- prepend-class [old-class new-class]
+  (println "prepend" new-class " to " old-class)
+  (cond
+    (nil? old-class) new-class
+    (coll? old-class) (cons new-class old-class)
+    :else [new-class old-class]))
+
 (defn- prevent-default [f]
   (when f
     (fn [e]
@@ -21,6 +28,6 @@
 
 (defn icon-button [opts content]
   [:a (-> opts
-          (assoc :class (icon-button-class))
+          (update :class prepend-class (icon-button-class))
           (update :on-click prevent-default))
    content])

--- a/src/main/atc/data/aircraft_configs.cljs
+++ b/src/main/atc/data/aircraft_configs.cljs
@@ -16,4 +16,7 @@
 
                    :min-speed 110
                    :cruise-speed 460
-                   :landing-speed 125}))
+                   :landing-speed 125
+
+                   :max-flight-level 410
+                   :cruise-flight-level 370}))

--- a/src/main/atc/data/units.cljc
+++ b/src/main/atc/data/units.cljc
@@ -1,4 +1,4 @@
-(ns atc.data.units 
+(ns atc.data.units
   (:require
    [clojure.math :refer [floor]]))
 
@@ -8,11 +8,15 @@
   ; just make it clean:
   (floor (* 3.28084 meters)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn m->nm [meters]
   (* 0.000539957 meters))
 
 (defn ft->m [feet]
   (* 0.3048 feet))
+
+(defn ft->fl [feet]
+  (/ feet 100))
 
 (defn nm->m [nautical-miles]
   (* 1852 nautical-miles))

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -72,6 +72,7 @@
                      ^String callsign, ^String radio-name, pilot
                      tx-frequency
                      state
+                     altitude-assignments
                      ^Vec3 position heading speed
                      commands]
   Simulated
@@ -107,6 +108,7 @@
                     :state :flight
                     :pilot (pilot/generate nil) ; TODO Pass in a preferred voice?
                     :position (vec3 250 250 (ft->m 20000))
+                    :altitude-assignments []
                     :heading 350
                     :speed 200}
                    data)))

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -4,9 +4,9 @@
    [atc.engine.aircraft.commands :refer [apply-commanded-inputs]]
    [atc.engine.aircraft.instructions :as instructions :refer [dispatch-instruction]]
    [atc.engine.config :refer [AircraftConfig]]
-   [atc.engine.model :refer [ICommunicator Simulated v+ Vec3 vec3]]
+   [atc.engine.model :refer [bearing-to ICommunicator Simulated v+ Vec3 vec3]]
    [atc.engine.pilot :as pilot]
-   [clojure.math :refer [cos sin to-radians]]))
+   [clojure.math :refer [cos floor sin to-radians]]))
 
 ; ======= Physics =========================================
 
@@ -20,6 +20,37 @@
 (defn altitude-agl-m [airport ^Aircraft aircraft]
   (- (:z (:position aircraft))
      (ft->m (last (:position airport)))))
+
+; ======= Helpers =========================================
+
+(defn departing-bearing [engine craft]
+  (let [id->fix (:game/navaids-by-id engine)
+        last-fix (->> craft
+                      :departure-fix
+                      id->fix)]
+    (bearing-to (:position (:airport engine))
+                last-fix)))
+
+(defn choose-cruise-altitude-fl [engine craft]
+  (let [default-fl (:cruise-flight-level (:config craft))
+        default-fl-10th (floor (/ default-fl 10))
+        alt-even? (= 0 (mod default-fl-10th 2))
+        bearing (departing-bearing engine craft)]
+    (cond
+      ; NEODD
+      (and (<= 0 bearing 179)
+           alt-even?)
+      (* 10 (- default-fl-10th 1))
+
+      (<= 0 bearing 179)
+      default-fl
+
+      ; SWEVEN
+      alt-even?
+      default-fl
+
+      :else
+      (* 10 (- default-fl-10th 1)))))
 
 
 ; ======= Radiology =======================================

--- a/src/main/atc/engine/aircraft/instructions_test.cljs
+++ b/src/main/atc/engine/aircraft/instructions_test.cljs
@@ -1,0 +1,24 @@
+(ns atc.engine.aircraft.instructions-test
+  (:require
+   [atc.data.units :refer [ft->m]]
+   [atc.engine.aircraft.instructions :refer [dispatch-instruction]]
+   [atc.engine.model :refer [vec3]]
+   [atc.util.testing :refer [create-engine]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest adjust-altitude-test
+  (testing "Track altitude assignment when adjusted"
+    (let [engine (create-engine)
+          craft {:position (vec3 0 0 (ft->m 10000))}
+          craft' (-> craft
+                     (dispatch-instruction engine [:adjust-altitude 22000]))
+          craft'' (-> craft'
+                      (dispatch-instruction engine [:adjust-altitude 8000]))]
+      (is (= [{:direction :climb
+               :altitude-ft 22000}]
+             (:altitude-assignments craft')))
+      (is (= [{:direction :climb
+               :altitude-ft 22000}
+              {:direction :descend
+               :altitude-ft 8000}]
+             (:altitude-assignments craft''))))))

--- a/src/main/atc/engine/aircraft_test.cljs
+++ b/src/main/atc/engine/aircraft_test.cljs
@@ -1,0 +1,21 @@
+(ns atc.engine.aircraft-test
+  (:require
+   [atc.data.aircraft-configs :as configs]
+   [atc.engine.aircraft :refer [choose-cruise-altitude-fl departing-bearing]]
+   [atc.util.testing :refer [create-engine roughly=]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest departing-bearing-test
+  (testing "Compute a rough departing bearing based on known navaids"
+    (let [engine (create-engine)
+          craft {:departure-fix "RBV"}]
+      (is (roughly= 244 (departing-bearing engine craft)
+                    :delta 0.5)))))
+
+(deftest choose-curise-altitude-fl-test
+  (testing "Follow SWEVEN rules"
+    (let [engine (create-engine)
+          craft {:departure-fix "RBV"
+                 :config configs/common-jet}]
+      (is (= 360 (choose-cruise-altitude-fl
+                   engine craft))))))

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -151,7 +151,7 @@
                      (get (:destination opts))
                      (rename-key :fix :departure-fix))
                  {:tx-frequency :self} ; NOTE: default to "my" frequency
-                 (select-keys opts [:origin :route])
+                 (select-keys opts [:origin :route :squawk])
                  (if arrival?
                    (arriving-aircraft-params this opts)
                    (departing-aircraft-params this opts)))]

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -3,7 +3,7 @@
    [archetype.util :refer [>evt]]
    [atc.config :as config]
    [atc.data.airports :refer [runway->heading runway-coords]]
-   [atc.data.units :refer [ft->m]]
+   [atc.data.units :refer [ft->m m->ft]]
    [atc.engine.aircraft :as aircraft :refer [choose-cruise-altitude-fl]]
    [atc.engine.aircraft.states :refer [update-state-machine]]
    [atc.engine.global :refer [dispatch-global-instruction]]
@@ -67,6 +67,9 @@
    :state :arriving
    :arrival-fix (->> (partial-arrival-route this craft)
                      last)
+   :altitude-assignments [{:direction :descend
+                           :altitude-ft (-> (:z position)
+                                            (m->ft))}]
    :tx-frequency (->> (:airport this)
                       :center-facilities
                       ; TODO Pick the actual closest center facility

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -11,6 +11,7 @@
                                               IGameEngine pending-communication
                                               prepare-pending-communication Simulated tick]]
    [atc.engine.queues :refer [run-queues]]
+   [atc.game.traffic.shared-util :refer [partial-arrival-route]]
    [atc.radio :as radio]
    [atc.util.maps :refer [rename-key]]
    [atc.voice.process :refer [build-machine]]))
@@ -57,11 +58,13 @@
                 :target-speed (min config/speed-limit-under-10k-kts
                                    (:cruise-speed config))}}))
 
-(defn- arriving-aircraft-params [this {:keys [config position heading]}]
+(defn- arriving-aircraft-params [this {:keys [config position heading] :as craft}]
   {:heading heading
    :position position
    :speed (:cruise-speed config)
    :state :arriving
+   :arrival-fix (->> (partial-arrival-route this craft)
+                     last)
    :tx-frequency (->> (:airport this)
                       :center-facilities
                       ; TODO Pick the actual closest center facility

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -475,6 +475,25 @@
 ; ======= "Help" functionality ============================
 
 (reg-event-fx
+  :help/identify-flight-strip
+  [trim-v]
+  (fn [_ [part]]
+    (let [msg (case part
+                :altitude-assignments "A list of altitude assignments for this craft in 100's of feet"
+                :arrival-fix "The fix through which this aircraft will arrive in our airspace"
+                :callsign "The aircraft's callsign"
+                :cruise-flight-level "The altitude (as Flight Level) to which the craft eventually should climb"
+                :departure-fix "The fix from which this aircraft will depart our airspace"
+                :destination "The aircraft's destination"
+                :origin "The airport from which this aircraft departed"
+                :route "The aircraft's route"
+                :squawk "The aircraft's assigned \"squawk\" identifier code"
+                :type "The aircraft's type identifier")]
+      {:dispatch [:radio-history/push
+                  {:speaker :system/help
+                   :text msg}]})))
+
+(reg-event-fx
   :help/identify-navaid
   [trim-v injected-engine (path :engine)]
   (fn [{engine :db} [id]]

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -54,6 +54,7 @@
         {:aircraft {:type :airline
                     :airline (pick-random random (keys all-airlines))
                     :flight-number (next-int random 20 9999)
+                    :origin (:id airport)
                     :destination destination
                     :route (-> airport (get-in [:departure-routes destination]))
 

--- a/src/main/atc/game/traffic/random.cljs
+++ b/src/main/atc/game/traffic/random.cljs
@@ -8,6 +8,13 @@
    [atc.game.traffic.shared :refer [position-arriving-aircraft]]
    [atc.util.seedable :refer [next-boolean next-int pick-random]]))
 
+(defn- next-squawk [random engine]
+  (loop [random random]
+    (let [v (next-int random 1000 7300)]
+      (if (some #(= v (:squawk %)) (vals (:aircraft engine)))
+        (recur random)
+        v))))
+
 (defrecord RandomTraffic [random]
   ITraffic
   (spawn-initial-arrivals [this engine]
@@ -37,6 +44,7 @@
                  :destination (:id airport)
                  :route (-> airport (get-in [:arrival-routes origin :route]))
                  :behavior {:will-get-weather? will-get-weather?}
+                 :squawk (next-squawk random engine)
                  :config configs/common-jet}]
       {:aircraft (position-arriving-aircraft engine craft)
 
@@ -44,7 +52,8 @@
        :delay-to-next-s 240}))
 
   (next-departure [_ {:keys [airport]
-                      runways :game/active-runways}]
+                      runways :game/active-runways
+                      :as engine}]
     (if-not runways
       {:delay-to-next-s 1}
 
@@ -60,6 +69,7 @@
 
                     ; TODO Round-robin runway selection, if multiple available
                     :runway (->> runways :departures first)
+                    :squawk (next-squawk random engine)
                     :config configs/common-jet}
 
          ; TODO This should at least depend on the spawned aircraft's speed, etc. Maybe "difficulty"?

--- a/src/main/atc/game/traffic/shared_test.cljs
+++ b/src/main/atc/game/traffic/shared_test.cljs
@@ -6,14 +6,9 @@
    [atc.game.traffic.shared :as shared :refer [grouping-navaid-of-route
                                                position-arriving-aircraft]]
    [atc.game.traffic.shared-util :refer [partial-arrival-route]]
-   [atc.subs-util :refer [navaids-by-id]]
-   [atc.util.testing :refer [roughly=]]
+   [atc.util.testing :refer [create-engine roughly=]]
    [cljs.test :refer-macros [deftest is testing]]
    [clojure.math :refer [sqrt]]))
-
-(defn- create-engine []
-  {:airport kjfk/airport
-   :game/navaids-by-id (navaids-by-id kjfk/airport)})
 
 (defn- aircraft-distance [craft1 craft2]
   (sqrt

--- a/src/main/atc/styles.cljs
+++ b/src/main/atc/styles.cljs
@@ -8,6 +8,7 @@
   [":root" {:*accent* theme/aircraft-tracked-obj
             :*background* theme/background
             :*background-secondary* theme/background-secondary
+            :*background-hover* theme/background-hover
             :*text* theme/text
             :*map-text* theme/map-label-opaque}]
 

--- a/src/main/atc/styles.cljs
+++ b/src/main/atc/styles.cljs
@@ -5,7 +5,8 @@
    [spade.core :refer [defclass defglobal]]))
 
 (defglobal window-styles
-  [":root" {:*background* theme/background
+  [":root" {:*accent* theme/aircraft-tracked-obj
+            :*background* theme/background
             :*background-secondary* theme/background-secondary
             :*text* theme/text
             :*map-text* theme/map-label-opaque}]

--- a/src/main/atc/theme.cljs
+++ b/src/main/atc/theme.cljs
@@ -2,6 +2,7 @@
 
 (def background "#000")
 (def background-secondary "#191d24")
+(def background-hover "#475366")
 (def text "#f4f7ff")
 
 (def action-destructive "#aa3333")

--- a/src/main/atc/util/testing.cljc
+++ b/src/main/atc/util/testing.cljc
@@ -1,6 +1,8 @@
 (ns atc.util.testing
   (:require
-   [atc.engine.model :refer [v- vec3 vmag]]))
+   [atc.data.airports.kjfk :as kjfk]
+   [atc.engine.model :refer [v- vec3 vmag]]
+   [atc.subs-util :refer [navaids-by-id]]))
 
 (defn- maybe->vec3
   "Coerce v into a vec3, if it looks vec3-like"
@@ -22,3 +24,8 @@
                     (vmag (v- a b)))]
      (<= (abs distance)
          delta))))
+
+(defn create-engine []
+  {:airport kjfk/airport
+   :game/navaids-by-id (navaids-by-id kjfk/airport)})
+

--- a/src/main/atc/views.cljs
+++ b/src/main/atc/views.cljs
@@ -3,8 +3,7 @@
    [archetype.util :refer [<sub]]
    [archetype.views.error-boundary :refer [error-boundary]]
    [atc.views.game :as game]
-   [atc.views.home :as home]
-   [atc.views.strips.host :refer [flight-strips-host]]))
+   [atc.views.home :as home]))
 
 (def ^:private pages
   {:game #'game/view
@@ -16,6 +15,5 @@
     (println "[router]" page args page-form)
 
     [error-boundary
-     page-form
-     [flight-strips-host]]))
+     page-form]))
 

--- a/src/main/atc/views.cljs
+++ b/src/main/atc/views.cljs
@@ -3,7 +3,8 @@
    [archetype.util :refer [<sub]]
    [archetype.views.error-boundary :refer [error-boundary]]
    [atc.views.game :as game]
-   [atc.views.home :as home]))
+   [atc.views.home :as home]
+   [atc.views.strips.host :refer [flight-strips-host]]))
 
 (def ^:private pages
   {:game #'game/view
@@ -15,5 +16,6 @@
     (println "[router]" page args page-form)
 
     [error-boundary
-     page-form]))
+     page-form
+     [flight-strips-host]]))
 

--- a/src/main/atc/views/game.cljs
+++ b/src/main/atc/views/game.cljs
@@ -17,6 +17,7 @@
    [atc.views.game.system-status :refer [system-status]]
    [atc.views.game.viewport :refer [viewport]]
    [atc.views.pause-screen :as pause-screen]
+   [atc.views.strips.host :refer [flight-strips-host]]
    [reagent.core :as r]
    [spade.core :refer [defattrs]]))
 
@@ -128,6 +129,8 @@
 
        [:div (system-status-container-attrs {:paused? paused?})
         [system-status]]
+
+       [flight-strips-host]
 
        (when paused?
          [pause-screen/view])])))

--- a/src/main/atc/views/strips/events.cljs
+++ b/src/main/atc/views/strips/events.cljs
@@ -1,13 +1,12 @@
 (ns atc.views.strips.events
   (:require
-   [re-frame.core :refer [reg-event-fx trim-v]]))
+   [re-frame.core :refer [path reg-event-db trim-v]]))
 
-(reg-event-fx
+(reg-event-db
   ::set-state
-  [trim-v]
-  (fn [{:keys [db]} [state]]
-    (when (= :popped-out state)
-      {:db (assoc-in db [:flight-strip-window] (js/window.open "" "flight-strips" "popup"))})))
+  [trim-v (path :flight-strips)]
+  (fn [flight-strips [state]]
+    (assoc flight-strips :state state)))
 
 (comment
   (re-frame.core/dispatch [::set-state :popped-out]))

--- a/src/main/atc/views/strips/events.cljs
+++ b/src/main/atc/views/strips/events.cljs
@@ -7,7 +7,6 @@
   [trim-v]
   (fn [{:keys [db]} [state]]
     (when (= :popped-out state)
-      (println "POP OUT")
       {:db (assoc-in db [:flight-strip-window] (js/window.open "" "flight-strips" "popup"))})))
 
 (comment

--- a/src/main/atc/views/strips/events.cljs
+++ b/src/main/atc/views/strips/events.cljs
@@ -1,0 +1,14 @@
+(ns atc.views.strips.events
+  (:require
+   [re-frame.core :refer [reg-event-fx trim-v]]))
+
+(reg-event-fx
+  ::set-state
+  [trim-v]
+  (fn [{:keys [db]} [state]]
+    (when (= :popped-out state)
+      (println "POP OUT")
+      {:db (assoc-in db [:flight-strip-window] (js/window.open "" "flight-strips" "popup"))})))
+
+(comment
+  (re-frame.core/dispatch [::set-state :popped-out]))

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -22,7 +22,8 @@
                                 :ease-out)]]}
   [:.controls {:display :flex
                :flex-direction :column
-               :pointer-events :all}]
+               :pointer-events :all
+               :user-select :none}]
   [:.actual {:pointer-events :all
              :height :100%
              :width (px width)}])

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -31,6 +31,7 @@
   (let [state (<sub [::subs/state])]
     (if (= state :popped-out)
       [browser-window {:window-name "flight-strips"
+                       :on-close #(>evt [::events/set-state :hidden])
                        :width width
                        :height 600}
        [flight-strips]]

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -1,0 +1,17 @@
+(ns atc.views.strips.host
+  (:require
+   ["react-dom" :as react-dom]
+   [applied-science.js-interop :as j]
+   [archetype.util :refer [<sub]]
+   [atc.views.strips.subs :as subs]
+   [reagent.core :as r]))
+
+(defn flight-strips []
+  [:div (str (<sub [:game/aircraft]))])
+
+(defn flight-strips-host []
+  (when-let [window (<sub [::subs/window])]
+    (println "PORTAL INTO " window)
+    (react-dom/createPortal
+      (r/as-element [flight-strips])
+      (j/get-in window [:document :body]))))

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -12,14 +12,20 @@
 
 (defattrs flight-strips-container-attrs [expanded?]
   {:display :flex
+   :align-items :center
+   :height :100%
+   :pointer-events :none
    :position :absolute
    :right (if expanded? 0 (px (- width)))
    :transition [[:all "120ms" (if expanded?
                                 :ease-in
                                 :ease-out)]]}
   [:.controls {:display :flex
-               :flex-direction :column}]
-  [:.actual {:width (px width)}])
+               :flex-direction :column
+               :pointer-events :all}]
+  [:.actual {:pointer-events :all
+             :height :100%
+             :width (px width)}])
 
 (defn flight-strips-host []
   (let [state (<sub [::subs/state])]
@@ -31,14 +37,14 @@
 
       [:div (flight-strips-container-attrs (= state :expanded))
        [:div.controls
-        [:button {:on-click #(>evt [::events/set-state :popped-out])}
+        [:button.interactive {:on-click #(>evt [::events/set-state :popped-out])}
          "^"]
         (case state
           :expanded
-          [:button {:on-click #(>evt [::events/set-state :hidden])}
+          [:button.interactive {:on-click #(>evt [::events/set-state :hidden])}
            ">>"]
 
-          [:button {:on-click #(>evt [::events/set-state :expanded])}
+          [:button.interactive {:on-click #(>evt [::events/set-state :expanded])}
            "<<"])]
 
        [:div.actual

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -3,6 +3,7 @@
    [archetype.util :refer [<sub >evt]]
    [atc.components.browser-window :refer [browser-window]]
    [atc.components.icon :refer [icon]]
+   [atc.components.icon-button :refer [icon-button]]
    [atc.views.strips.events :as events]
    [atc.views.strips.subs :as subs]
    [atc.views.strips.view :refer [flight-strips]]
@@ -21,8 +22,12 @@
    :transition [[:all "120ms" (if expanded?
                                 :ease-in
                                 :ease-out)]]}
-  [:.controls {:display :flex
+  [:.controls {:background-color :*background-secondary*
+               :border-top-left-radius (px 4)
+               :border-bottom-left-radius (px 4)
+               :display :flex
                :flex-direction :column
+               :padding (px 2)
                :pointer-events :all
                :user-select :none}]
   [:.actual {:pointer-events :all
@@ -40,14 +45,16 @@
 
       [:div (flight-strips-container-attrs (= state :expanded))
        [:div.controls
-        [:button.interactive {:on-click #(>evt [::events/set-state :popped-out])}
+        [icon-button {:on-click #(>evt [::events/set-state :popped-out])
+                      :aria-label "Pop out flight strips into separate window"}
          (icon :open-in-new)]
+
         (case state
           :expanded
-          [:button.interactive {:on-click #(>evt [::events/set-state :hidden])}
+          [icon-button {:on-click #(>evt [::events/set-state :hidden])}
            (icon :right-panel-close)]
 
-          [:button.interactive {:on-click #(>evt [::events/set-state :expanded])}
+          [icon-button {:on-click #(>evt [::events/set-state :expanded])}
            (icon :right-panel-open)])]
 
        [:div.actual

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -2,6 +2,7 @@
   (:require
    [archetype.util :refer [<sub >evt]]
    [atc.components.browser-window :refer [browser-window]]
+   [atc.components.icon :refer [icon]]
    [atc.views.strips.events :as events]
    [atc.views.strips.subs :as subs]
    [atc.views.strips.view :refer [flight-strips]]
@@ -40,14 +41,14 @@
       [:div (flight-strips-container-attrs (= state :expanded))
        [:div.controls
         [:button.interactive {:on-click #(>evt [::events/set-state :popped-out])}
-         "^"]
+         (icon :open-in-new)]
         (case state
           :expanded
           [:button.interactive {:on-click #(>evt [::events/set-state :hidden])}
-           ">>"]
+           (icon :right-panel-close)]
 
           [:button.interactive {:on-click #(>evt [::events/set-state :expanded])}
-           "<<"])]
+           (icon :right-panel-open)])]
 
        [:div.actual
         [flight-strips]]])))

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -1,41 +1,13 @@
 (ns atc.views.strips.host
   (:require
-   ["react-dom" :as react-dom]
-   [applied-science.js-interop :as j]
    [archetype.util :refer [<sub]]
-   [atc.styles :refer [window-styles]]
+   [atc.components.browser-window :refer [browser-window]]
    [atc.views.strips.subs :as subs]
-   [reagent.core :as r]
-   [spade.core :refer [defattrs]]
-   [spade.react :as spade-react]
-   [spade.runtime :as spade-runtime]))
-
-; NOTE: This is a hack! spade doesn't currently support automatically
-; rendering global styles into a style-container
-(defn window-styles-mounter []
-  #_{:clj-kondo/ignore [:invalid-arity]} ; Kondo is wrong here...?
-  (spade-runtime/ensure-style!
-    :global
-    (meta #'window-styles)
-    (constantly "window-styles")
-    (constantly {:css window-styles})
-    nil))
-
-(defattrs flight-strips-attrs []
-  {:background "red"})
-
-(defn flight-strips []
-  [window-styles-mounter]
-  [:div (flight-strips-attrs)
-   (str (<sub [:game/aircraft]))])
-
-(defn- flight-strips-root []
-  (let [window (<sub [::subs/window])]
-    [spade-react/with-dom (j/get-in window [:document :head])
-     [flight-strips]]))
+   [atc.views.strips.view :refer [flight-strips]]))
 
 (defn flight-strips-host []
-  (when-let [window (<sub [::subs/window])]
-    (react-dom/createPortal
-      (r/as-element [flight-strips-root])
-      (j/get-in window [:document :body]))))
+  (when (= :popped-out (<sub [::subs/state]))
+    [browser-window {:window-name "flight-strips"
+                     :width 800
+                     :height 600}
+     [flight-strips]]))

--- a/src/main/atc/views/strips/host.cljs
+++ b/src/main/atc/views/strips/host.cljs
@@ -3,15 +3,39 @@
    ["react-dom" :as react-dom]
    [applied-science.js-interop :as j]
    [archetype.util :refer [<sub]]
+   [atc.styles :refer [window-styles]]
    [atc.views.strips.subs :as subs]
-   [reagent.core :as r]))
+   [reagent.core :as r]
+   [spade.core :refer [defattrs]]
+   [spade.react :as spade-react]
+   [spade.runtime :as spade-runtime]))
+
+; NOTE: This is a hack! spade doesn't currently support automatically
+; rendering global styles into a style-container
+(defn window-styles-mounter []
+  #_{:clj-kondo/ignore [:invalid-arity]} ; Kondo is wrong here...?
+  (spade-runtime/ensure-style!
+    :global
+    (meta #'window-styles)
+    (constantly "window-styles")
+    (constantly {:css window-styles})
+    nil))
+
+(defattrs flight-strips-attrs []
+  {:background "red"})
 
 (defn flight-strips []
-  [:div (str (<sub [:game/aircraft]))])
+  [window-styles-mounter]
+  [:div (flight-strips-attrs)
+   (str (<sub [:game/aircraft]))])
+
+(defn- flight-strips-root []
+  (let [window (<sub [::subs/window])]
+    [spade-react/with-dom (j/get-in window [:document :head])
+     [flight-strips]]))
 
 (defn flight-strips-host []
   (when-let [window (<sub [::subs/window])]
-    (println "PORTAL INTO " window)
     (react-dom/createPortal
-      (r/as-element [flight-strips])
+      (r/as-element [flight-strips-root])
       (j/get-in window [:document :body]))))

--- a/src/main/atc/views/strips/subs.cljs
+++ b/src/main/atc/views/strips/subs.cljs
@@ -10,3 +10,26 @@
   ::state
   :<- [::context]
   :-> :state)
+
+(reg-sub
+  ::strips
+  :<- [:game/airport]
+  :<- [:game/tracked-aircraft]
+  :-> (fn [[airport aircraft]]
+        (->> aircraft
+             (map
+               (fn [craft]
+                 (-> craft
+                     (dissoc :position :heading :speed)
+                     (assoc :arrival? (= (:id airport)
+                                         (:destination craft)))))))))
+
+(reg-sub
+  ::arrival-strips
+  :<- [::strips]
+  :-> (partial filter :arrival?))
+
+(reg-sub
+  ::departure-strips
+  :<- [::strips]
+  :-> (partial remove :arrival?))

--- a/src/main/atc/views/strips/subs.cljs
+++ b/src/main/atc/views/strips/subs.cljs
@@ -3,5 +3,10 @@
    [re-frame.core :refer [reg-sub]]))
 
 (reg-sub
-  ::window
-  :-> :flight-strip-window)
+  ::context
+  :-> :flight-strips)
+
+(reg-sub
+  ::state
+  :<- [::context]
+  :-> :state)

--- a/src/main/atc/views/strips/subs.cljs
+++ b/src/main/atc/views/strips/subs.cljs
@@ -1,0 +1,7 @@
+(ns atc.views.strips.subs
+  (:require
+   [re-frame.core :refer [reg-sub]]))
+
+(reg-sub
+  ::window
+  :-> :flight-strip-window)

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -17,18 +17,17 @@
 (defattrs flight-strip-attrs []
   (let [column-border [[(px 1) :solid :*text*]]]
     [:&
-     {:display :grid
+     {:border [[(px 2) :outset :*map-text*]]
+      :border-radius (px 2)
+      :display :grid
       :grid-template-columns [["1fr" "1fr" "1fr" "3fr"]]
       :font-family :monospace
-      :width :100%
-      ; :height (px 70)
       :cursor :default}
 
      [:.aircraft-identification :.squawk-column :.col3 :.route
       {:display :flex
        :flex-direction :column
        :justify-content :space-between
-       :height :100%
        :padding [[(px 4) 0]]}]
 
      [:.aircraft-identification :.squawk-column :.col3
@@ -78,7 +77,9 @@
       :squawk-column [nil
                       nil ; TODO entry fix
 ]
-      :route [:<> "TODO assigned altitudes"]}]
+      :route [:<>
+              [:div.route-body "TODO assigned altitudes"]
+              [:div.destination (:destination strip)]]}]
 
     ; Departure:
     (let [cruise-flight-level 350] ; TODO compute
@@ -107,8 +108,18 @@
    :cursor :default
    :height :100%
    :overflow-y :auto
+   :padding (px 4)
    :user-select :none}
+  [:.strips-group-title {:background-color :*accent*
+                         :border [[(px 2) :outset :*map-text*]]
+                         :border-radius (px 2)
+                         :font-family :sans-serif
+                         :margin 0
+                         :padding (px 12)
+                         :text-align :center
+                         :text-transform :uppercase}]
   [:.strips-group {:padding 0
+                   :margin 0
                    :list-style-type :none}])
 
 (defn flight-strips []

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [archetype.util :refer [<sub >evt]]
     [atc.views.strips.events :as events]
+    [atc.views.strips.subs :as subs]
     [spade.core :refer [defattrs]]))
 
 (defattrs flight-strips-attrs []
@@ -9,6 +10,7 @@
 
 (defn flight-strips []
   [:div (flight-strips-attrs)
-   [:button {:on-click #(>evt [::events/set-state :expanded])}
-    "Pop in"]
+   (when (= :popped-out (<sub [::subs/state]))
+     [:button {:on-click #(>evt [::events/set-state :hidden])}
+      "Pop in"])
    [:div.weather (str (<sub [:game/weather]))]])

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -24,7 +24,7 @@
       :font-family :monospace
       :cursor :default}
 
-     [:.aircraft-identification :.squawk-column :.col3 :.route
+     [:.aircraft-identification :.col3 :.route
       {:display :flex
        :flex-direction :column
        :justify-content :space-between
@@ -35,7 +35,7 @@
 
      [:.squawk-column {:border-left column-border
                        :border-right column-border}
-      [:.middle {:padding (px 4)}]
+      [:.squawk :.middle :.bottom {:padding (px 4)}]
       [:.middle {:border-top column-border
                  :border-bottom column-border}]]
 
@@ -54,7 +54,7 @@
     [:div.blank nbsp]]
 
    [:div.squawk-column
-    [:div.squask nbsp] ; TODO
+    [:div.squawk nbsp] ; TODO
     [:div.middle (or sc-mid nbsp)]
     [:div.bottom (or sc-bottom nbsp)]]
 

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -6,7 +6,9 @@
     [spade.core :refer [defattrs]]))
 
 (defattrs flight-strips-attrs []
-  {:background "red"})
+  {:background :*background-secondary*
+   :color :*text*
+   :height :100%})
 
 (defn flight-strips []
   [:div (flight-strips-attrs)

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -82,7 +82,7 @@
               [:div.destination (:destination strip)]]}]
 
     ; Departure:
-    (let [cruise-flight-level 350] ; TODO compute
+    (let [{:keys [cruise-flight-level]} strip]
       [flight-strip-form
        {:callsign callsign
         :config config

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -75,8 +75,7 @@
      {:callsign callsign
       :config config
       :squawk-column [nil
-                      nil ; TODO entry fix
-]
+                      (:arrival-fix strip)]
       :route [:<>
               [:div.route-body "TODO assigned altitudes"]
               [:div.destination (:destination strip)]]}]

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -44,6 +44,11 @@
      [:.route {:border-left column-border
                :padding (px 4)}]]))
 
+(defn- create-help-attrs [kind]
+  {:on-context-menu (fn [e]
+                     (.preventDefault e)
+                     (>evt [:help/identify-flight-strip kind]))})
+
 (defn- flight-strip-form [{:keys [callsign config squawk
                                   col3
                                   route
@@ -51,12 +56,12 @@
                            [sc-mid sc-bottom] :squawk-column}]
   [:li (flight-strip-attrs)
    [:div.aircraft-identification
-    [:div.callsign callsign]
-    [:div.craft-type (:type config)]
+    [:div.callsign (create-help-attrs :callsign) callsign]
+    [:div.craft-type (create-help-attrs :type) (:type config)]
     [:div.blank nbsp]]
 
    [:div.squawk-column
-    [:div.squawk squawk]
+    [:div.squawk (create-help-attrs :squawk) squawk]
     [:div.middle (or sc-mid nbsp)]
     [:div.bottom (or sc-bottom nbsp)]]
 
@@ -109,11 +114,14 @@
       :config config
       :squawk squawk
       :squawk-column [nil
-                      (:arrival-fix strip)]
+                      [:span (create-help-attrs :arrival-fix)
+                       (:arrival-fix strip)]]
       :route [:<>
-              [:div.route-body [altitude-assignments
-                                (:altitude-assignments strip)]]
-              [:div.destination (:destination strip)]]}]
+              [:div.altitudes (create-help-attrs :altitude-assignments)
+               [altitude-assignments
+                (:altitude-assignments strip)]]
+              [:div.destination (create-help-attrs :destination)
+               (:destination strip)]]}]
 
     ; Departure:
     (let [{:keys [cruise-flight-level]} strip]
@@ -122,11 +130,15 @@
         :config config
         :squawk squawk
         :squawk-column [nil
-                        cruise-flight-level]
+                        [:span (create-help-attrs :cruise-flight-level)
+                         cruise-flight-level]]
         :col3 [:<>
-               [:div.origin (:origin strip)]
-               [:div.departure-fix (:departure-fix strip)]]
-        :route (get-in strip [:route :route])}])))
+               [:div.origin (create-help-attrs :origin)
+                (:origin strip)]
+               [:div.departure-fix (create-help-attrs :departure-fix)
+                (:departure-fix strip)]]
+        :route [:div.actual-route (create-help-attrs :route)
+                (get-in strip [:route :route])]}])))
 
 (defn- flight-strip-group [& {subscription :<sub :keys [title]}]
   (let [strips (<sub subscription)]

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -1,0 +1,14 @@
+(ns atc.views.strips.view
+  (:require
+    [archetype.util :refer [<sub >evt]]
+    [atc.views.strips.events :as events]
+    [spade.core :refer [defattrs]]))
+
+(defattrs flight-strips-attrs []
+  {:background "red"})
+
+(defn flight-strips []
+  [:div (flight-strips-attrs)
+   [:button {:on-click #(>evt [::events/set-state :expanded])}
+    "Pop in"]
+   [:div.weather (str (<sub [:game/weather]))]])

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -1,18 +1,100 @@
 (ns atc.views.strips.view
   (:require
-    [archetype.util :refer [<sub >evt]]
-    [atc.views.strips.events :as events]
-    [atc.views.strips.subs :as subs]
-    [spade.core :refer [defattrs]]))
+   [archetype.util :refer [<sub >evt]]
+   [atc.views.strips.events :as events]
+   [atc.views.strips.subs :as subs]
+   [garden.units :refer [px]]
+   [goog.string :as gstring]
+   [spade.core :refer [defattrs]]))
+
+(defn- pop-in-button []
+  (when (= :popped-out (<sub [::subs/state]))
+    [:button {:on-click #(>evt [::events/set-state :hidden])}
+     "Pop in"]))
+
+(defattrs flight-strip-attrs []
+  {:display :flex
+   :font-family :monospace
+   :width :100%
+   :height (px 70)
+   :cursor :default}
+
+  [:.aircraft-identification :.col2 :.col3 :.route
+   {:display :flex
+    :flex-direction :column
+    :justify-content :space-between
+    :height :100%
+    :padding (px 4)}])
+
+(defn- flight-strip-form [{:keys [callsign config
+                                  col2 col3
+                                  route
+                                  table]}]
+  [:li (flight-strip-attrs)
+   [:div.aircraft-identification
+    [:div.callsign callsign]
+    [:div.craft-type (:type config)]
+    [:div.blank (gstring/unescapeEntities "&nbsp;")]]
+
+   [:div.col2
+    col2]
+
+   [:div.col3
+    col3]
+
+   [:div.route
+    route]
+
+   [:div.table
+    ; TODO
+    (str table)]])
+
+(defn- flight-strip [{:keys [callsign config arrival?] :as strip}]
+  (if arrival?
+    [flight-strip-form
+     {:callsign callsign
+      :config config
+      :col2 nil ; TODO entry fix
+      :route [:<> "TODO altitudes"]}]
+
+    ; Departure:
+    [flight-strip-form
+     {:callsign callsign
+      :config config
+      :col2 nil ; TODO cruise flight level
+      :col3 [:<>
+             [:div.origin (:origin strip)]
+             [:div.departure-fix (:departure-fix strip)]]
+      :route (:route strip)}]))
+
+(defn- flight-strip-group [& {subscription :<sub :keys [title]}]
+  (let [strips (<sub subscription)]
+    [:<>
+     [:h2.strips-group-title title]
+     [:ul.strips-group
+      (for [strip strips]
+        ^{:key (:callsign strip)}
+        [flight-strip strip])]]))
 
 (defattrs flight-strips-attrs []
   {:background :*background-secondary*
    :color :*text*
-   :height :100%})
+   :cursor :default
+   :height :100%
+   :overflow-y :auto
+   :user-select :none}
+  [:.strips-group {:padding 0
+                   :list-style-type :none}])
 
 (defn flight-strips []
   [:div (flight-strips-attrs)
-   (when (= :popped-out (<sub [::subs/state]))
-     [:button {:on-click #(>evt [::events/set-state :hidden])}
-      "Pop in"])
-   [:div.weather (str (<sub [:game/weather]))]])
+   [pop-in-button]
+
+   ; TODO Arrival strips should be grouped by runway
+   [flight-strip-group
+    :title "Arrivals"
+    :<sub [::subs/arrival-strips]]
+
+   [flight-strip-group
+    :title "Departures"
+    :<sub [::subs/departure-strips]]])

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -1,6 +1,7 @@
 (ns atc.views.strips.view
   (:require
    [archetype.util :refer [<sub >evt]]
+   [atc.components.icon :refer [icon]]
    [atc.data.units :refer [ft->fl]]
    [atc.views.strips.events :as events]
    [atc.views.strips.subs :as subs]
@@ -14,7 +15,7 @@
 (defn- pop-in-button []
   (when (= :popped-out (<sub [::subs/state]))
     [:button {:on-click #(>evt [::events/set-state :hidden])}
-     "Pop in"]))
+     (icon :pip)]))
 
 (defattrs flight-strip-attrs []
   (let [column-border [[(px 1) :solid :*text*]]]

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -42,7 +42,7 @@
      [:.route {:border-left column-border
                :padding (px 4)}]]))
 
-(defn- flight-strip-form [{:keys [callsign config
+(defn- flight-strip-form [{:keys [callsign config squawk
                                   col3
                                   route
                                   table]
@@ -54,7 +54,7 @@
     [:div.blank nbsp]]
 
    [:div.squawk-column
-    [:div.squawk nbsp] ; TODO
+    [:div.squawk squawk]
     [:div.middle (or sc-mid nbsp)]
     [:div.bottom (or sc-bottom nbsp)]]
 
@@ -69,11 +69,12 @@
       ; TODO
       (str table)])])
 
-(defn- flight-strip [{:keys [callsign config arrival?] :as strip}]
+(defn- flight-strip [{:keys [callsign config arrival? squawk] :as strip}]
   (if arrival?
     [flight-strip-form
      {:callsign callsign
       :config config
+      :squawk squawk
       :squawk-column [nil
                       (:arrival-fix strip)]
       :route [:<>
@@ -85,6 +86,7 @@
       [flight-strip-form
        {:callsign callsign
         :config config
+        :squawk squawk
         :squawk-column [nil
                         cruise-flight-level]
         :col3 [:<>

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -15,7 +15,8 @@
 
 (defn- pop-in-button []
   (when (= :popped-out (<sub [::subs/state]))
-    [icon-button {:on-click #(>evt [::events/set-state :hidden])
+    [icon-button {:class :pop-in-button
+                  :on-click #(>evt [::events/set-state :hidden])
                   :aria-label "Return flight strips back into main window"}
      (icon :pip)]))
 
@@ -160,6 +161,10 @@
    :overflow-y :auto
    :padding (px 4)
    :user-select :none}
+
+  ; Make it full width:
+  [:.pop-in-button {:display :flex}]
+
   [:.strips-group-title {:background-color :*accent*
                          :border [[(px 2) :outset :*map-text*]]
                          :border-radius (px 2)

--- a/src/main/atc/views/strips/view.cljs
+++ b/src/main/atc/views/strips/view.cljs
@@ -2,6 +2,7 @@
   (:require
    [archetype.util :refer [<sub >evt]]
    [atc.components.icon :refer [icon]]
+   [atc.components.icon-button :refer [icon-button]]
    [atc.data.units :refer [ft->fl]]
    [atc.views.strips.events :as events]
    [atc.views.strips.subs :as subs]
@@ -14,7 +15,8 @@
 
 (defn- pop-in-button []
   (when (= :popped-out (<sub [::subs/state]))
-    [:button {:on-click #(>evt [::events/set-state :hidden])}
+    [icon-button {:on-click #(>evt [::events/set-state :hidden])
+                  :aria-label "Return flight strips back into main window"}
      (icon :pip)]))
 
 (defattrs flight-strip-attrs []


### PR DESCRIPTION
<img width="1337" alt="Screenshot 2023-09-12 at 2 09 42 PM" src="https://github.com/dhleong/cljs-atc/assets/816150/9b56d015-5e49-4ee8-9c5b-916424ebdf64">

There's a lot going on with this PR!

- We added a new `[browser-window]` component to abstract rendering arbitrary content in an external window. This is pretty neat! It is fully reactive
- We now try to disable the dark reader browser extension so colors don't get weird
- Of course, we're rendering arrival and departure aircraft. You can pop this out (thanks to the above component) into a separate window, for folks with multiple monitors or something
- We're now using Google Material Symbols to render some UI icons
- We now generate unique aircraft squawk codes for each craft
- We also pick an appropriate cruise altitude for each craft
- Assigning an altitude to an aircraft will append it to a list that we render in the strip for arriving aircraft
- All pieces of the flight strip can be right-clicked to learn what it is