### PR TITLE
Add support for visual approaches

### DIFF
--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -84,8 +84,8 @@
           velocity-vector (vec3 vx vy 0)]
       (update this :position v+ velocity-vector)))
 
-  (command [this instruction]
-    (dispatch-instruction this (:context (meta instruction)) instruction))
+  (command [this engine instruction]
+    (dispatch-instruction this engine instruction))
 
   ICommunicator
   (pending-communication [this]

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -73,8 +73,8 @@
                      ^Vec3 position heading speed
                      commands]
   Simulated
-  (tick [this dt]
-    (let [this (apply-commanded-inputs this commands dt)
+  (tick [this engine dt]
+    (let [this (apply-commanded-inputs this engine commands dt)
           ; TODO: Vertical speed?
           raw-speed (* (speed->mps speed) dt)
           heading-radians (heading->radians (:heading this))

--- a/src/main/atc/engine/aircraft.cljs
+++ b/src/main/atc/engine/aircraft.cljs
@@ -103,7 +103,8 @@
                     :callsign callsign
                     :radio-name radio-name
                     :state :flight
-                    :pilot (pilot/generate nil) ; TODO Pass in a preferred voice?
+                    :pilot (or (:pilot data)
+                               (pilot/generate nil)) ; TODO Pass in a preferred voice?
                     :position (vec3 250 250 (ft->m 20000))
                     :altitude-assignments []
                     :heading 350

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -5,7 +5,8 @@
    [atc.data.units :refer [nm->m]]
    [atc.engine.aircraft.commands.altitude :refer [apply-altitude]]
    [atc.engine.aircraft.commands.direct :refer [apply-direct]]
-   [atc.engine.aircraft.commands.helpers :refer [apply-rate normalize-heading]]
+   [atc.engine.aircraft.commands.helpers :refer [normalize-heading]]
+   [atc.engine.aircraft.commands.speed :refer [apply-target-speed]]
    [atc.engine.aircraft.commands.steering :refer [apply-steering]]
    [atc.engine.aircraft.commands.visual-approach
     :refer [apply-report-field-in-sight apply-visual-approach]]
@@ -88,20 +89,6 @@
   (case approach-type
     :ils (apply-ils-approach aircraft command dt)
     :visual (apply-visual-approach aircraft command dt)))
-
-
-; ======= Speed ===========================================
-
-(defn apply-target-speed [{from :speed :as aircraft} commanded-speed dt]
-  (if (= from commanded-speed)
-    aircraft
-
-    (apply-rate
-      aircraft
-      :target-speed [:speed]
-      {-1 :deceleration
-       1 :acceleration}
-      from commanded-speed dt)))
 
 
 ; ======= Public interface ================================

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -9,7 +9,7 @@
    [atc.engine.aircraft.commands.speed :refer [apply-target-speed]]
    [atc.engine.aircraft.commands.steering :refer [apply-steering]]
    [atc.engine.aircraft.commands.visual-approach
-    :refer [apply-report-field-in-sight apply-visual-approach]]
+    :refer [apply-report-field-in-sight apply-visual-approach landed?]]
    [atc.engine.model :refer [angle-down-to bearing-to distance-to-squared]]
    [clojure.math :refer [pow]]))
 
@@ -24,8 +24,6 @@
 
 (def ^:private glide-slope-angle-degrees 3)
 (def ^:private glide-slope-width-degrees 1.4)
-
-(def ^:private landed-distance-m 5)
 
 (defn- within-localizer?
   "Returns the [runway-threshold distance2] if within the runway's localizer, else nil"
@@ -49,8 +47,7 @@
     ;  that's no good. 
     (cond-> aircraft
       ; Detect "landing"
-      (<= distance-to-runway2
-          landed-distance-m)
+      (landed? aircraft runway-start distance-to-runway2)
       (assoc :state :landed
              :commands {})
 

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -99,6 +99,7 @@
     (:direct commands) (apply-direct (:direct commands) dt)
     (:cleared-approach commands) (apply-approach engine (:cleared-approach commands) dt)
     (:report-field-in-sight commands) (apply-report-field-in-sight
+                                        engine
                                         (:report-field-in-sight commands)
                                         dt)
     (:target-altitude commands) (apply-altitude (:target-altitude commands) dt)

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -4,31 +4,13 @@
    [atc.data.airports :as airports]
    [atc.data.units :refer [nm->m]]
    [atc.engine.aircraft.commands.altitude :refer [apply-altitude]]
+   [atc.engine.aircraft.commands.direct :refer [apply-direct]]
    [atc.engine.aircraft.commands.helpers :refer [apply-rate normalize-heading]]
    [atc.engine.aircraft.commands.steering :refer [apply-steering]]
    [atc.engine.aircraft.commands.visual-approach
     :refer [apply-report-field-in-sight apply-visual-approach]]
    [atc.engine.model :refer [angle-down-to bearing-to distance-to-squared]]
    [clojure.math :refer [pow]]))
-
-; ======= Direct-to-point nav =============================
-
-; This is the distance in meters squared at which an aircraft is considered
-; to have "arrived" at its :direct target. We include quite a bit of slop
-; to avoid excess steering, since you should maintain heading if you pass
-; the point and don't have any other direction
-(def ^:private over-coordinate-distance-m2 (pow 6500 2.))
-
-(defn- apply-direct [aircraft commanded-to dt]
-  ; NOTE: This is temporary; the real logic should account for resuming course,
-  ; intercept heading, crossing altitude, etc.
-  (let [distance2 (distance-to-squared (:position aircraft) commanded-to)]
-    (if (< distance2 over-coordinate-distance-m2)
-      ; We're "at" the destination; we can stop heading towards it now
-      (update aircraft :commands dissoc :direct)
-
-      (let [bearing-to-destination (bearing-to (:position aircraft) commanded-to)]
-        (apply-steering aircraft bearing-to-destination dt)))))
 
 
 ; ======= Approach course following =======================

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -172,7 +172,10 @@
 ; I suppose this could be a defmulti...
 (defn- apply-approach [aircraft {:keys [approach-type] :as command} dt]
   (case approach-type
-    :ils (apply-ils-approach aircraft command dt)))
+    :ils (apply-ils-approach aircraft command dt)
+
+    ; TODO special visual approach logic, probably
+    :visual (apply-ils-approach aircraft command dt)))
 
 
 ; ======= Speed ===========================================

--- a/src/main/atc/engine/aircraft/commands.cljs
+++ b/src/main/atc/engine/aircraft/commands.cljs
@@ -85,19 +85,19 @@
       aircraft))
 
 ; I suppose this could be a defmulti...
-(defn- apply-approach [aircraft {:keys [approach-type] :as command} dt]
+(defn- apply-approach [aircraft engine {:keys [approach-type] :as command} dt]
   (case approach-type
     :ils (apply-ils-approach aircraft command dt)
-    :visual (apply-visual-approach aircraft command dt)))
+    :visual (apply-visual-approach aircraft engine command dt)))
 
 
 ; ======= Public interface ================================
 
-(defn apply-commanded-inputs [aircraft, commands dt]
+(defn apply-commanded-inputs [aircraft engine commands dt]
   (cond-> aircraft
     (:heading commands) (apply-steering (:heading commands) dt)
     (:direct commands) (apply-direct (:direct commands) dt)
-    (:cleared-approach commands) (apply-approach (:cleared-approach commands) dt)
+    (:cleared-approach commands) (apply-approach engine (:cleared-approach commands) dt)
     (:report-field-in-sight commands) (apply-report-field-in-sight
                                         (:report-field-in-sight commands)
                                         dt)

--- a/src/main/atc/engine/aircraft/commands/altitude.cljs
+++ b/src/main/atc/engine/aircraft/commands/altitude.cljs
@@ -1,0 +1,18 @@
+(ns atc.engine.aircraft.commands.altitude
+  (:require
+   [atc.engine.aircraft.commands.helpers :refer [apply-rate]]))
+
+(defn apply-altitude [{{from :z} :position :as aircraft} commanded-altitude dt]
+  (if (or (= from commanded-altitude)
+          ; The aircraft cannot climb if it's going too slow! There's a bit
+          ; of an assumption here that the :landing-speed will never be less
+          ; than this, but that seems... safe?
+          (< (:speed aircraft) (:min-speed (:config aircraft))))
+    aircraft
+
+    (apply-rate
+      aircraft
+      :target-altitude [:position :z]
+      {-1 :descent-rate
+       1 :climb-rate}
+      from commanded-altitude dt)))

--- a/src/main/atc/engine/aircraft/commands/direct.cljs
+++ b/src/main/atc/engine/aircraft/commands/direct.cljs
@@ -1,0 +1,24 @@
+(ns atc.engine.aircraft.commands.direct
+  (:require
+   [atc.engine.aircraft.commands.steering :refer [apply-steering]]
+   [atc.engine.model :refer [bearing-to distance-to-squared]]
+   [clojure.math :refer [pow]]))
+
+; ======= Direct-to-point nav =============================
+
+; This is the distance in meters squared at which an aircraft is considered
+; to have "arrived" at its :direct target. We include quite a bit of slop
+; to avoid excess steering, since you should maintain heading if you pass
+; the point and don't have any other direction
+(def ^:private over-coordinate-distance-m2 (pow 6500 2.))
+
+(defn apply-direct [aircraft commanded-to dt]
+  ; NOTE: This is temporary; the real logic should account for resuming course,
+  ; intercept heading, crossing altitude, etc.
+  (let [distance2 (distance-to-squared (:position aircraft) commanded-to)]
+    (if (< distance2 over-coordinate-distance-m2)
+      ; We're "at" the destination; we can stop heading towards it now
+      (update aircraft :commands dissoc :direct)
+
+      (let [bearing-to-destination (bearing-to (:position aircraft) commanded-to)]
+        (apply-steering aircraft bearing-to-destination dt)))))

--- a/src/main/atc/engine/aircraft/commands/helpers.cljs
+++ b/src/main/atc/engine/aircraft/commands/helpers.cljs
@@ -3,6 +3,11 @@
    [atc.data.units :refer [ft->m]]
    [atc.engine.model :refer [vec3]]))
 
+(defn normalize-heading [h]
+  (if (< h 0)
+    (+ h 360)
+    (mod h 360)))
+
 (defn primary-airport-position [airport]
   (vec3 0 0 (ft->m (last (:position airport)))))
 
@@ -16,3 +21,20 @@
   (when (seq parts)
     {:message (concat ["center," craft ";"] parts)
      :from (build-utterance-from craft)}))
+
+
+; ======= Building blocks =================================
+
+(defn apply-rate [aircraft command-key path rate-keys from commanded-value dt]
+  (let [sign (if (> commanded-value from) 1 -1)
+        rate-key (rate-keys sign)
+        rate (get-in aircraft [:config rate-key])
+        new-speed (+ from (* sign rate dt))]
+    (if (<= (abs (- commanded-value new-speed))
+            (* rate 0.5))
+      (-> aircraft
+          (assoc-in path commanded-value)  ; close enough; snap to
+          (update :commands dissoc command-key))
+
+      (-> aircraft
+          (assoc-in path new-speed)))))

--- a/src/main/atc/engine/aircraft/commands/helpers.cljs
+++ b/src/main/atc/engine/aircraft/commands/helpers.cljs
@@ -1,4 +1,10 @@
-(ns atc.engine.aircraft.commands.helpers)
+(ns atc.engine.aircraft.commands.helpers
+  (:require
+   [atc.data.units :refer [ft->m]]
+   [atc.engine.model :refer [vec3]]))
+
+(defn primary-airport-position [airport]
+  (vec3 0 0 (ft->m (last (:position airport)))))
 
 ; ======= Radiology =======================================
 

--- a/src/main/atc/engine/aircraft/commands/speed.cljs
+++ b/src/main/atc/engine/aircraft/commands/speed.cljs
@@ -1,0 +1,14 @@
+(ns atc.engine.aircraft.commands.speed
+  (:require
+   [atc.engine.aircraft.commands.helpers :refer [apply-rate]]))
+
+(defn apply-target-speed [{from :speed :as aircraft} commanded-speed dt]
+  (if (= from commanded-speed)
+    aircraft
+
+    (apply-rate
+      aircraft
+      :target-speed [:speed]
+      {-1 :deceleration
+       1 :acceleration}
+      from commanded-speed dt)))

--- a/src/main/atc/engine/aircraft/commands/steering.cljs
+++ b/src/main/atc/engine/aircraft/commands/steering.cljs
@@ -1,0 +1,33 @@
+(ns atc.engine.aircraft.commands.steering
+  (:require
+   [atc.engine.aircraft.commands.helpers :refer [normalize-heading]]))
+
+(defn shorter-steer-direction [from to]
+  ; With thanks to: https://math.stackexchange.com/a/2898118
+  (let [delta (- (mod (- to from -540)
+                      360)
+                 180)]
+    (if (>= delta 0)
+      :right
+      :left)))
+
+(defn apply-steering [{from :heading commands :commands :as aircraft}
+                       commanded-to dt]
+  (if (= from commanded-to)
+    aircraft
+
+    ; TODO at slower speeds, small craft might use a turn 2 rate (IE: 2x turn rate)
+    ; TODO similarly, at higher speeds, large craft might use a half turn rate
+    (let [turn-sign (case (or (:steer-direction commands)
+                              (shorter-steer-direction from commanded-to))
+                      :right  1
+                      :left  -1)
+          degrees-per-second (get-in aircraft [:config :turn-rate])
+          turn-amount (* degrees-per-second dt)
+          new-heading (normalize-heading (+ from (* turn-sign turn-amount)))]
+      (if (<= (abs (- commanded-to new-heading))
+              (* turn-amount 0.5))
+        (-> aircraft
+            (assoc :heading commanded-to)  ; close enough; snap to
+            (update :commands dissoc :steer-direction))
+        (assoc aircraft :heading new-heading)))))

--- a/src/main/atc/engine/aircraft/commands/steering_test.cljs
+++ b/src/main/atc/engine/aircraft/commands/steering_test.cljs
@@ -1,6 +1,6 @@
-(ns atc.engine.aircraft.commands-test
+(ns atc.engine.aircraft.commands.steering-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [atc.engine.aircraft.commands :refer [shorter-steer-direction]]))
+            [atc.engine.aircraft.commands.steering :refer [shorter-steer-direction]]))
 
 (deftest shorter-steer-direction-test
   (testing "Simple checks"

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -283,6 +283,7 @@
                               (v* runway-vector distance-to-aircraft))]
     (cljs.pprint/pprint
       {:behavior (get-in aircraft [:behavior])
+       :altitude-ft (atc.data.units/m->ft (get-in aircraft [:position :z]))
        :bearing-to-aircraft bearing-to-aircraft
        :aircraft-bearing (:heading aircraft)
        :delta-to-runway-angle ['<= (abs (- target-heading bearing-to-aircraft))

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -148,8 +148,8 @@
                              runway-threshold)
         distance-to-aircraft (vmag vector-to-aircraft)
         runway-vector (-> (bearing-to->vec
-                            runway-threshold
-                            runway-end)
+                            runway-end
+                            runway-threshold)
                           (normalize))
 
         final-turn-position (v+
@@ -232,8 +232,8 @@
                              runway-threshold)
         distance-to-aircraft (vmag vector-to-aircraft)
         runway-vector (-> (bearing-to->vec
-                            runway-threshold
-                            runway-end)
+                            runway-end
+                            runway-threshold)
                           (normalize))
         final-turn-position (v* runway-vector distance-to-aircraft)]
     (cljs.pprint/pprint

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -20,9 +20,9 @@
             distance-sq (distance-to-squared (:position craft) airport-position)]
         (<= distance-sq (squared visibility-m)))))
 
-(defn apply-report-field-in-sight [craft {:keys [airport-position weather]} _dt]
+(defn apply-report-field-in-sight [craft engine {:keys [airport-position]} _dt]
   (cond-> craft
-    (can-see-airport? craft airport-position weather)
+    (can-see-airport? craft airport-position (:weather engine))
     (-> (update :commands dissoc :report-field-in-sight)
         (utter-once "field in sight"))))
 

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -193,7 +193,7 @@
             (+ (:z runway-threshold)
                landed-altitude-delta-m)))))
 
-(def ^:private min-glide-slope-degrees 0.6)
+(def ^:private min-glide-slope-degrees 1.6)
 
 (defmethod apply-visual-approach-leg :final
   [aircraft _engine {:keys [airport runway]} dt]

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -117,7 +117,7 @@
         ; We can turn base if:
         ;  - We have not been commanded to extend our downwind, AND
         ;  - The angle from us to the ruway is 45 or less, AND
-        ;  - TODO There are no other aircraft on base
+        ;  - There are no other aircraft on base
         can-turn-base? (and (not (get-in aircraft [:behavior :extend-downwind]))
                             (<= (abs (- target-heading bearing-to-aircraft))
                                 45)

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -2,13 +2,13 @@
   (:require
    [atc.data.airports :as airports :refer [runway->heading runway-coords]]
    [atc.data.units :refer [ft->m nm->m sm->m]]
-   [atc.engine.aircraft.commands.speed :refer [apply-target-speed]]
    [atc.engine.aircraft.commands.altitude :refer [apply-altitude]]
    [atc.engine.aircraft.commands.direct :refer [apply-direct]]
    [atc.engine.aircraft.commands.helpers :refer [normalize-heading utter-once]]
+   [atc.engine.aircraft.commands.speed :refer [apply-target-speed]]
    [atc.engine.aircraft.commands.steering :refer [apply-steering]]
    [atc.engine.model :refer [angle-down-to bearing-to bearing-to->vec
-                             distance-to-squared normalize v* vmag]]
+                             distance-to-squared normalize v* v+ vmag]]
    [atc.util.math :refer [squared]]))
 
 
@@ -152,7 +152,9 @@
                             runway-end)
                           (normalize))
 
-        final-turn-position (v* runway-vector distance-to-aircraft)
+        final-turn-position (v+
+                              runway-threshold
+                              (v* runway-vector distance-to-aircraft))
         target-altitude (ft->m (+ 500 (last (:position airport))))
 
         can-turn-final? (<= (distance-to-squared

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -1,8 +1,11 @@
 (ns atc.engine.aircraft.commands.visual-approach
   (:require
-   [atc.data.units :refer [sm->m]]
-   [atc.engine.aircraft.commands.helpers :refer [utter-once]]
-   [atc.engine.model :refer [distance-to-squared]]))
+   [atc.data.airports :as airports :refer [runway->heading runway-coords]]
+   [atc.data.units :refer [ft->m sm->m]]
+   [atc.engine.aircraft.commands.altitude :refer [apply-altitude]]
+   [atc.engine.aircraft.commands.helpers :refer [normalize-heading utter-once]]
+   [atc.engine.aircraft.commands.steering :refer [apply-steering]]
+   [atc.engine.model :refer [bearing-to distance-to-squared]]))
 
 
 ; ======= Report field in sight ===========================
@@ -18,3 +21,43 @@
     (can-see-airport? craft airport-position weather)
     (-> (update :commands dissoc :report-field-in-sight)
         (utter-once "field in sight"))))
+
+
+; ======= Visual Approaches ===============================
+
+(defn compute-approach-leg [_aircraft {:keys [airport runway]}]
+  (let [_runway-heading (airports/runway->heading airport runway)]
+    ; TODO
+    :enter-downwind))
+
+(defmulti ^:private apply-visual-approach-leg
+  (fn [aircraft _cmd _dt]
+    (get-in aircraft [:behavior :visual-approach-state])))
+
+(defmethod apply-visual-approach-leg :downwind
+  [aircraft {:keys [airport runway]} dt]
+  (let [target-heading (-> (runway->heading airport runway)
+                           (+ 180)
+                           (normalize-heading))
+        target-altitude (ft->m (+ 1000 (last (:position airport))))
+        [runway-threshold _] (runway-coords airport runway)
+        bearing-to-aircraft (bearing-to runway-threshold (:position aircraft))
+        can-turn-base? (and (not (get-in aircraft [:behavior :extend-downwind]))
+                            (<= (- target-heading 45)
+                                bearing-to-aircraft
+                                (+ target-heading 45)))]
+    (if can-turn-base?
+      (-> aircraft
+          (update :behavior assoc :visual-approach-state :downwind))
+
+      (-> aircraft
+          (apply-altitude target-altitude dt)
+          (apply-steering target-heading dt)))))
+
+(defn apply-visual-approach [aircraft cmd dt]
+  (let [leg (or (get-in aircraft [:behavior :visual-approach-state])
+                (compute-approach-leg aircraft cmd))]
+    (-> aircraft
+        (assoc-in [:behavior :visual-approach-state] leg)
+        (apply-visual-approach-leg cmd dt))))
+

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -105,10 +105,14 @@
         target-altitude (ft->m (+ 1000 (last (:position airport))))
         [runway-threshold _] (runway-coords airport runway)
         bearing-to-aircraft (bearing-to runway-threshold (:position aircraft))
+
+        ; We can turn base if:
+        ;  - We have not been commanded to extend our downwind, AND
+        ;  - The angle from us to the ruway is 45 or less, AND
+        ;  - TODO There are no other aircraft on base
         can-turn-base? (and (not (get-in aircraft [:behavior :extend-downwind]))
-                            (<= (- target-heading 45)
-                                bearing-to-aircraft
-                                (+ target-heading 45)))]
+                            (<= (abs (- target-heading bearing-to-aircraft))
+                                45))]
     (if can-turn-base?
       (-> aircraft
           (update :behavior assoc :visual-approach-state :base))

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -3,9 +3,11 @@
    [atc.data.airports :as airports :refer [runway->heading runway-coords]]
    [atc.data.units :refer [ft->m sm->m]]
    [atc.engine.aircraft.commands.altitude :refer [apply-altitude]]
+   [atc.engine.aircraft.commands.direct :refer [apply-direct]]
    [atc.engine.aircraft.commands.helpers :refer [normalize-heading utter-once]]
    [atc.engine.aircraft.commands.steering :refer [apply-steering]]
-   [atc.engine.model :refer [bearing-to distance-to-squared]]))
+   [atc.engine.model :refer [angle-down-to bearing-to bearing-to->vec
+                             distance-to-squared normalize v* vmag]]))
 
 
 ; ======= Report field in sight ===========================
@@ -34,6 +36,9 @@
   (fn [aircraft _cmd _dt]
     (get-in aircraft [:behavior :visual-approach-state])))
 
+
+; ======= Downwind leg ====================================
+
 (defmethod apply-visual-approach-leg :downwind
   [aircraft {:keys [airport runway]} dt]
   (let [target-heading (-> (runway->heading airport runway)
@@ -53,6 +58,80 @@
       (-> aircraft
           (apply-altitude target-altitude dt)
           (apply-steering target-heading dt)))))
+
+
+; ======= Base leg ========================================
+
+(def ^:private turn-final-distance-sq-m (* 500 500))
+
+(defmethod apply-visual-approach-leg :base
+  [aircraft {:keys [airport runway]} dt]
+  (let [[runway-threshold runway-end] (runway-coords airport runway)
+        vector-to-aircraft (bearing-to->vec
+                             (:position aircraft)
+                             runway-threshold)
+        distance-to-aircraft (vmag vector-to-aircraft)
+        runway-vector (-> (bearing-to->vec
+                            runway-threshold
+                            runway-end)
+                          (normalize))
+
+        final-turn-position (v* runway-vector distance-to-aircraft)
+        target-altitude (ft->m (+ 500 (last (:position airport))))
+
+        can-turn-final? (<= (distance-to-squared
+                              (:position aircraft)
+                              final-turn-position)
+                            turn-final-distance-sq-m)]
+    (if can-turn-final?
+      (-> aircraft
+          (update :behavior assoc :visual-approach-state :final))
+
+      (-> aircraft
+          (apply-altitude target-altitude dt)
+          (apply-direct final-turn-position dt)))))
+
+
+; ======= Final approach ==================================
+
+(def ^:private landed-distance-m 5)
+(def ^:private min-glide-slope-degrees 1.6)
+
+(defmethod apply-visual-approach-leg :final
+  [aircraft {:keys [airport runway]} dt]
+  (let [[runway-start _] (runway-coords airport runway)
+        distance-to-runway2 (distance-to-squared
+                              (:position aircraft) runway-start)]
+    (cond-> aircraft
+      ; Detect "landing"
+      (<= distance-to-runway2
+          landed-distance-m)
+      (assoc :state :landed
+             :commands {})
+
+      ; Descend down to runway threshold
+      (>= (angle-down-to (:position aircraft) runway-start)
+          min-glide-slope-degrees)
+      (->
+        ; Ensure there's no competing altitude
+        (update :commands dissoc :target-altitude)
+
+        ; TODO Slow down
+
+        ; Descend toward runway
+        (apply-altitude (:z runway-start) dt))
+
+      ; Always ensure we turn onto course
+      :always
+      (->
+        ; We no longer need to maintain any specific heading
+        (update :commands dissoc :heading :steer-direction)
+
+        ; Steer toward the runway threshold
+        (apply-direct runway-start dt)))))
+
+
+; ======= Primary entry point =============================
 
 (defn apply-visual-approach [aircraft cmd dt]
   (let [leg (or (get-in aircraft [:behavior :visual-approach-state])

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -31,6 +31,11 @@
 
 (def ^:private heading-delta 15)
 
+; NOTE: We accept a smaller delta here to avoid false positives. We could
+; probably do some math to ensure we're positioned correctly relative to
+; the runway threshold instead, but... this is faster for now.
+(def ^:private base-heading-delta 5)
+
 (defn compute-approach-leg [aircraft {:keys [airport runway]}]
   (let [[runway-threshold _] (runway-coords airport runway)
         runway-heading (airports/runway->heading airport runway)
@@ -54,15 +59,15 @@
       :downwind
 
       ; left base leg
-      (<= (- left-base-heading heading-delta)
+      (<= (- left-base-heading base-heading-delta)
           (:heading aircraft)
-          (+ left-base-heading heading-delta))
+          (+ left-base-heading base-heading-delta))
       :base
 
       ; right base leg
-      (<= (- right-base-heading heading-delta)
+      (<= (- right-base-heading base-heading-delta)
           (:heading aircraft)
-          (+ right-base-heading heading-delta))
+          (+ right-base-heading base-heading-delta))
       :base
 
       :else :enter-downwind)))

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -218,3 +218,27 @@
         (assoc-in [:behavior :visual-approach-state] leg)
         (apply-visual-approach-leg engine cmd dt))))
 
+(comment
+
+  #_{:clj-kondo/ignore [:unresolved-namespace]}
+  (let [aircraft (second (first (:aircraft (:engine @re-frame.db/app-db))))
+        {:keys [airport runway]} (get-in aircraft [:commands :cleared-approach])
+        [runway-threshold runway-end] (runway-coords airport runway)
+        bearing-to-aircraft (bearing-to runway-threshold (:position aircraft))
+        vector-to-aircraft (bearing-to->vec
+                             (:position aircraft)
+                             runway-threshold)
+        distance-to-aircraft (vmag vector-to-aircraft)
+        runway-vector (-> (bearing-to->vec
+                            runway-threshold
+                            runway-end)
+                          (normalize))
+        final-turn-position (v* runway-vector distance-to-aircraft)]
+    (cljs.pprint/pprint
+      {:behavior (get-in aircraft [:behavior])
+       :bearing-to-aircraft bearing-to-aircraft
+
+       :can-turn-final? (<= (distance-to-squared
+                              (:position aircraft)
+                              final-turn-position)
+                            turn-final-distance-sq-m)})))

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -73,7 +73,7 @@
       :else :enter-downwind)))
 
 (defmulti ^:private apply-visual-approach-leg
-  (fn [aircraft _cmd _dt]
+  (fn [aircraft _engine _cmd _dt]
     (get-in aircraft [:behavior :visual-approach-state])))
 
 
@@ -82,7 +82,7 @@
 (def ^:private downwind-leg-distance-sq (squared (nm->m 5.5)))
 
 (defmethod apply-visual-approach-leg :enter-downwind
-  [aircraft {:keys [airport _runway]} dt]
+  [aircraft _engine {:keys [airport _runway]} dt]
   (let [distance-sq (distance-to-squared
                       aircraft
                       (:position airport))]
@@ -98,7 +98,7 @@
 ; ======= Downwind leg ====================================
 
 (defmethod apply-visual-approach-leg :downwind
-  [aircraft {:keys [airport runway]} dt]
+  [aircraft _engine {:keys [airport runway]} dt]
   (let [target-heading (-> (runway->heading airport runway)
                            (+ 180)
                            (normalize-heading))
@@ -124,7 +124,7 @@
 (def ^:private turn-final-distance-sq-m (squared 500))
 
 (defmethod apply-visual-approach-leg :base
-  [aircraft {:keys [airport runway]} dt]
+  [aircraft _engine {:keys [airport runway]} dt]
   (let [[runway-threshold runway-end] (runway-coords airport runway)
         vector-to-aircraft (bearing-to->vec
                              (:position aircraft)
@@ -158,7 +158,7 @@
 (def ^:private min-glide-slope-degrees 1.6)
 
 (defmethod apply-visual-approach-leg :final
-  [aircraft {:keys [airport runway]} dt]
+  [aircraft _engine {:keys [airport runway]} dt]
   (let [[runway-start _] (runway-coords airport runway)
         distance-to-runway2 (distance-to-squared
                               (:position aircraft) runway-start)]
@@ -194,10 +194,10 @@
 
 ; ======= Primary entry point =============================
 
-(defn apply-visual-approach [aircraft cmd dt]
+(defn apply-visual-approach [aircraft engine cmd dt]
   (let [leg (or (get-in aircraft [:behavior :visual-approach-state])
                 (compute-approach-leg aircraft cmd))]
     (-> aircraft
         (assoc-in [:behavior :visual-approach-state] leg)
-        (apply-visual-approach-leg cmd dt))))
+        (apply-visual-approach-leg engine cmd dt))))
 

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -39,7 +39,9 @@
                             runway-threshold)
         downwind-heading (-> runway-heading
                              (+ 180)
-                             (normalize-heading))]
+                             (normalize-heading))
+        left-base-heading (+ runway-heading 90)
+        right-base-heading (+ runway-heading 90)]
     (cond
       (<= (- runway-heading heading-delta)
           bearing-to-runway
@@ -51,7 +53,17 @@
           (+ downwind-heading heading-delta))
       :downwind
 
-      ; TODO base leg
+      ; left base leg
+      (<= (- left-base-heading heading-delta)
+          (:heading aircraft)
+          (+ left-base-heading heading-delta))
+      :base
+
+      ; right base leg
+      (<= (- right-base-heading heading-delta)
+          (:heading aircraft)
+          (+ right-base-heading heading-delta))
+      :base
 
       :else :enter-downwind)))
 

--- a/src/main/atc/engine/aircraft/commands/visual_approach.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach.cljs
@@ -2,6 +2,7 @@
   (:require
    [atc.data.airports :as airports :refer [runway->heading runway-coords]]
    [atc.data.units :refer [ft->m sm->m]]
+   [atc.engine.aircraft.commands :refer [apply-target-speed]]
    [atc.engine.aircraft.commands.altitude :refer [apply-altitude]]
    [atc.engine.aircraft.commands.direct :refer [apply-direct]]
    [atc.engine.aircraft.commands.helpers :refer [normalize-heading utter-once]]
@@ -57,6 +58,7 @@
 
       (-> aircraft
           (apply-altitude target-altitude dt)
+          (apply-target-speed (:landing-speed (:config aircraft)) dt)
           (apply-steering target-heading dt)))))
 
 
@@ -89,6 +91,7 @@
 
       (-> aircraft
           (apply-altitude target-altitude dt)
+          (apply-target-speed (:landing-speed (:config aircraft)) dt)
           (apply-direct final-turn-position dt)))))
 
 
@@ -116,7 +119,8 @@
         ; Ensure there's no competing altitude
         (update :commands dissoc :target-altitude)
 
-        ; TODO Slow down
+        ; Slow down
+        (apply-target-speed (:min-speed (:config aircraft)) dt)
 
         ; Descend toward runway
         (apply-altitude (:z runway-start) dt))

--- a/src/main/atc/engine/aircraft/commands/visual_approach_test.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach_test.cljs
@@ -3,15 +3,18 @@
    [atc.data.airports.kjfk :as kjfk]
    [atc.data.units :refer [ft->m nm->m]]
    [atc.engine.aircraft.commands.helpers :refer [primary-airport-position]]
-   [atc.engine.aircraft.commands.visual-approach :refer [can-see-airport?]]
-   [atc.engine.model :refer [vec3]]
+   [atc.engine.aircraft.commands.visual-approach :refer [any-aircraft-on-leg?
+                                                         can-see-airport?]]
+   [atc.engine.core :refer [map->Engine]]
+   [atc.engine.model :refer [command spawn-aircraft vec3]]
+   [atc.util.testing :refer [create-engine]]
    [clojure.test :refer [deftest is testing]]))
 
 (deftest can-see-airport?-test
   (testing "Don't break when there's *no* weather"
     (is (true? (can-see-airport?
                  {:position (vec3 0 (nm->m 8) (ft->m 2000))}
-                 (vec3 0 0 (ft->m (last (:position kjfk/airport))))
+                 (primary-airport-position kjfk/airport)
                  {:wind-heading 200 :wind-kts 4}))))
 
   (testing "High visibility can see the airport"
@@ -25,3 +28,25 @@
                   {:position (vec3 0 (nm->m 8) (ft->m 2000))}
                   (primary-airport-position kjfk/airport)
                   {:visibility-sm 2})))))
+
+(deftest any-aircraft-on-leg?-test
+  (testing "Detect aircraft on base leg"
+    (let [engine (-> (create-engine)
+                     (map->Engine)
+                     (spawn-aircraft {:airline "DAL"
+                                      :flight-number 22
+                                      :destination "KJFK"
+                                      :position {:x 0 :y 0}
+                                      ; NOTE: Prevent trying to use voice:
+                                      :pilot {}})
+                     (command {:callsign "DAL22"
+                               :instructions [[:cleared-approach :visual "13L"]]}
+                              nil)
+                     (update-in [:aircraft "DAL22" :behavior]
+                                assoc
+                                :visual-approach-state :base))]
+      (is (seq (get-in engine [:aircraft "DAL22" :commands])))
+      (is (seq (get-in engine [:aircraft "DAL22" :behavior])))
+      (is (some?
+            (any-aircraft-on-leg?
+              engine "KJFK" "13L" :base))))))

--- a/src/main/atc/engine/aircraft/commands/visual_approach_test.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach_test.cljs
@@ -2,6 +2,7 @@
   (:require
    [atc.data.airports.kjfk :as kjfk]
    [atc.data.units :refer [ft->m nm->m]]
+   [atc.engine.aircraft.commands.helpers :refer [primary-airport-position]]
    [atc.engine.aircraft.commands.visual-approach :refer [can-see-airport?]]
    [atc.engine.model :refer [vec3]]
    [clojure.test :refer [deftest is testing]]))
@@ -16,11 +17,11 @@
   (testing "High visibility can see the airport"
     (is (true? (can-see-airport?
                  {:position (vec3 0 (nm->m 8) (ft->m 2000))}
-                 (vec3 0 0 (ft->m (last (:position kjfk/airport))))
+                 (primary-airport-position kjfk/airport)
                  {:visibility-sm 10}))))
 
   (testing "Low visibility cannot see the airport"
     (is (false? (can-see-airport?
                   {:position (vec3 0 (nm->m 8) (ft->m 2000))}
-                  (vec3 0 0 (ft->m (last (:position kjfk/airport))))
+                  (primary-airport-position kjfk/airport)
                   {:visibility-sm 2})))))

--- a/src/main/atc/engine/aircraft/commands/visual_approach_test.cljs
+++ b/src/main/atc/engine/aircraft/commands/visual_approach_test.cljs
@@ -4,7 +4,8 @@
    [atc.data.units :refer [ft->m nm->m]]
    [atc.engine.aircraft.commands.helpers :refer [primary-airport-position]]
    [atc.engine.aircraft.commands.visual-approach :refer [any-aircraft-on-leg?
-                                                         can-see-airport?]]
+                                                         can-see-airport?
+                                                         compute-approach-leg]]
    [atc.engine.core :refer [map->Engine]]
    [atc.engine.model :refer [command spawn-aircraft vec3]]
    [atc.util.testing :refer [create-engine]]
@@ -50,3 +51,11 @@
       (is (some?
             (any-aircraft-on-leg?
               engine "KJFK" "13L" :base))))))
+
+(deftest compute-approach-leg-test
+  (testing "Detect base leg approach"
+    ; Right base:
+    (let [cmd {:aircraft kjfk/airport
+               :runway "04L"}
+          aircraft {:heading 310}]
+      (is (= :base (compute-approach-leg aircraft cmd))))))

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -149,8 +149,7 @@
         ; the primary airport; in that case we just provide the
         ; relevant airport's relative position
         (update :commands assoc :report-field-in-sight
-                {:airport-position (primary-airport-position airport)
-                 :weather weather}))))
+                {:airport-position (primary-airport-position airport)}))))
 
 (defmethod dispatch-instruction
   :verify-atis

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -41,7 +41,7 @@
                 craft
                 (primary-airport-position (:airport context))
                 (:weather context))))
-    (utter craft "unable; I can't see the field yet")
+    (utter craft "unable visual approach; I can't see the field yet")
 
     :else (-> craft
             (assoc :state :cleared-approach)

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -1,8 +1,8 @@
 (ns atc.engine.aircraft.instructions
   (:require
-   [atc.data.units :as units :refer [ft->m]]
-   [atc.engine.aircraft.commands.visual-approach :refer [can-see-airport?]]
-   [atc.engine.model :refer [vec3]]))
+   [atc.data.units :as units]
+   [atc.engine.aircraft.commands.helpers :refer [primary-airport-position]]
+   [atc.engine.aircraft.commands.visual-approach :refer [can-see-airport?]]))
 
 (defn- utter [craft & utterance]
   (update craft ::utterance-parts conj utterance))
@@ -31,8 +31,17 @@
     (not (contains? (:game/airport-runway-ids context) runway))
     (utter craft "unable" runway)
 
-    (contains? #{:visual :rnav} approach-type)
+    (= :rnav approach-type)
     (utter craft "unable" (name approach-type))
+
+    ; TODO Actually you shouldn't clear for visual approach
+    ; unless they've reported the field in sight
+    (and (= :visual approach-type)
+         (not (can-see-airport?
+                craft
+                (primary-airport-position (:airport context))
+                (:weather context))))
+    (utter craft "unable; I can't see the field yet")
 
     :else (-> craft
             (assoc :state :cleared-approach)
@@ -140,8 +149,7 @@
         ; the primary airport; in that case we just provide the
         ; relevant airport's relative position
         (update :commands assoc :report-field-in-sight
-                {:airport-position (vec3 0 0 (ft->m
-                                               (last (:position airport))))
+                {:airport-position (primary-airport-position airport)
                  :weather weather}))))
 
 (defmethod dispatch-instruction

--- a/src/main/atc/engine/aircraft/instructions.cljs
+++ b/src/main/atc/engine/aircraft/instructions.cljs
@@ -7,7 +7,7 @@
 (defn- utter [craft & utterance]
   (update craft ::utterance-parts conj utterance))
 
-(defmulti dispatch-instruction (fn [_craft _context [instruction]] instruction))
+(defmulti dispatch-instruction (fn [_craft _engine [instruction]] instruction))
 
 (defmethod dispatch-instruction
   :adjust-altitude

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -86,7 +86,7 @@
   ; since we aren't, properly. Technically we should have a separate Simulator
   ; protocol and implement that to be more correct...
   Simulated
-  (tick [this _dt]
+  (tick [this _context _dt]
     (let [now (js/Date.now)
 
           dt (* time-scale
@@ -98,7 +98,7 @@
           ; Tick all aircraft
           updated-aircraft (reduce
                              (fn [m callsign]
-                               (update m callsign tick dt))
+                               (update m callsign tick this dt))
                              aircraft
                              (keys aircraft))
 

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -21,9 +21,7 @@
     (loop [simulated (prepare-pending-communication simulated)
            instructions (vec instructions)]
       (if (seq instructions)
-        (recur (engine-model/command simulated (with-meta
-                                                 (first instructions)
-                                                 {:context context}))
+        (recur (engine-model/command simulated context (first instructions))
                (next instructions))
 
         (do
@@ -118,9 +116,9 @@
           ; And process any "queued" events (like generating departures)
           (run-queues))))
 
-  (command [this command]
-    ; NOTE: The Engine actually receives a full Command object so we know where
-    ; to dispatch it and to whom.
+  (command [this command _instuction]
+    ; NOTE: The Engine receives a full Command object as its context, so we
+    ; know where to dispatch it and to whom.
     (let [{:keys [callsign global? instructions]} command]
       (cond
         global?

--- a/src/main/atc/engine/core.cljs
+++ b/src/main/atc/engine/core.cljs
@@ -154,7 +154,7 @@
                      (get (:destination opts))
                      (rename-key :fix :departure-fix))
                  {:tx-frequency :self} ; NOTE: default to "my" frequency
-                 (select-keys opts [:origin :route :squawk])
+                 (select-keys opts [:origin :pilot :route :squawk])
                  (if arrival?
                    (arriving-aircraft-params this opts)
                    (departing-aircraft-params this opts)))]

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -8,7 +8,7 @@
   (tick [this dt]
         "Update this simulated item by [dt] seconds")
 
-  (command [this instruction]
+  (command [this context instruction]
            "Process an instruction, of the form [:instruction ...args]"))
 
 (defprotocol ICommunicator

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -5,7 +5,7 @@
 (defprotocol Simulated
   "Anything that is managed by the simulation"
 
-  (tick [this dt]
+  (tick [this context dt]
         "Update this simulated item by [dt] seconds")
 
   (command [this context instruction]

--- a/src/main/atc/engine/model.cljc
+++ b/src/main/atc/engine/model.cljc
@@ -128,8 +128,7 @@
         to (vec3 to)
         elevation (- (:z from) (:z to))]
     (to-degrees
-      ; NOTE: Rather than involve any sqrts we just square elevation
-      (atan2 (* elevation elevation)
-             (vmag2
+      (atan2 elevation
+             (vmag
                (v- (vec3 from 0)
                    (vec3 to 0)))))))

--- a/src/main/atc/engine/model_test.cljs
+++ b/src/main/atc/engine/model_test.cljs
@@ -1,0 +1,14 @@
+(ns atc.engine.model-test
+  (:require
+   [atc.engine.model :refer [angle-down-to]]
+   [atc.util.testing :refer [roughly=]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest angle-down-to-test
+  (testing "Compute angle to ground position"
+    (is (= 45 (angle-down-to
+                {:x 0 :y 10 :z 12}
+                {:x 0 :y 0 :z 2})))
+    (is (roughly= 31 (angle-down-to
+                       {:x 0 :y 10 :z 8}
+                       {:x 0 :y 0 :z 2})))))

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -554,7 +554,7 @@
                          :traffic :debug}])
 
   (dispatch [::voice-handle-text "delta twenty two report field in sight"])
-  (dispatch [::voice-handle-text "delta twenty two cleared visual approach runway one three right"])
+  (dispatch [::voice-handle-text "delta twenty two cleared visual approach runway zero four left"])
 
   (dispatch [::voice-handle-text "delta twenty two turn right heading one eight zero"])
   (dispatch [::voice-handle-text "delta twenty two contact center point eight good day"])

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -547,6 +547,14 @@
 
   (dispatch [:weather/refresh])
 
+  (dispatch [:game/init {:airport-id :kjfk
+                         :arrivals? true
+                         :departures? true
+                         :voice-input? true
+                         :traffic :debug}])
+
+  (dispatch [::voice-handle-text "delta twenty two report field in sight"])
+
   (dispatch [::voice-handle-text "delta twenty two turn right heading one eight zero"])
   (dispatch [::voice-handle-text "delta twenty two contact center point eight good day"])
   (dispatch [::voice-handle-text "attention all aircraft information alpha is current"]))

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -554,6 +554,7 @@
                          :traffic :debug}])
 
   (dispatch [::voice-handle-text "delta twenty two report field in sight"])
+  (dispatch [::voice-handle-text "delta twenty two cleared visual approach runway one three right"])
 
   (dispatch [::voice-handle-text "delta twenty two turn right heading one eight zero"])
   (dispatch [::voice-handle-text "delta twenty two contact center point eight good day"])

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -143,7 +143,7 @@
   [injected-engine]
   (fn [{:keys [db]} _]
     (when-let [engine (:engine db)]
-      (let [engine' (engine-model/tick engine nil)
+      (let [engine' (engine-model/tick engine nil nil)
             event-metadata {:elapsed-s (:elapsed-s engine')}
             new-events (map
                          (fn [event-vec]

--- a/src/main/atc/events.cljs
+++ b/src/main/atc/events.cljs
@@ -92,7 +92,7 @@
   (fn [engine [command]]
     (when engine
       (println "dispatching command: " command)
-      (engine-model/command engine command))))
+      (engine-model/command engine command nil))))
 
 (reg-event-fx
   :game/init

--- a/src/main/atc/game.cljs
+++ b/src/main/atc/game.cljs
@@ -14,7 +14,8 @@
 
 (def ^:private traffic-spec
   (ds/or {:random (ds/or {:with-seed {(ds/opt :seed) number?}
-                          :default-seed (s/spec #{:random})})}))
+                          :default-seed (s/spec #{:random})})
+          :debug (s/spec #{:debug})}))
 
 (def ^:private game-options-spec
   (ds/spec

--- a/src/main/atc/game/traffic/debug.cljs
+++ b/src/main/atc/game/traffic/debug.cljs
@@ -1,0 +1,29 @@
+(ns atc.game.traffic.debug
+  (:require
+   [atc.data.aircraft-configs :as configs]
+   [atc.data.units :refer [ft->m nm->m]]
+   [atc.engine.model :refer [spawn-aircraft vec3]]
+   [atc.game.traffic.model :refer [ITraffic]]))
+
+(defrecord DebugTraffic []
+  ITraffic
+  (spawn-initial-arrivals [_ engine]
+    (let [engine' (-> engine
+                      (spawn-aircraft
+                        {:type :airline
+                         :airline "DAL"
+                         :flight-number 22
+                         :config configs/common-jet
+                         :destination "KJFK"
+                         :heading 300
+                         :position (vec3
+                                     (nm->m 10)
+                                     (nm->m 10)
+                                     (ft->m 4000))}))]
+      {:engine engine'
+       :delay-to-next-s (* 24 3600)}))
+
+  (next-arrival [_ _]
+    {:delay-to-next-s (* 24 3600)})
+  (next-departure [_ _]
+    {:delay-to-next-s (* 24 3600)}))

--- a/src/main/atc/game/traffic/factory.cljs
+++ b/src/main/atc/game/traffic/factory.cljs
@@ -1,5 +1,6 @@
 (ns atc.game.traffic.factory
   (:require
+   [atc.game.traffic.debug :refer [->DebugTraffic]]
    [atc.game.traffic.filtered :refer [->FilteredTraffic]]
    [atc.game.traffic.model :refer [->ValidatedTraffic]]
    [atc.game.traffic.random :refer [->RandomTraffic]]
@@ -15,7 +16,12 @@
 
       [:random [:with-seed {:seed seed}]]
       (->RandomTraffic
-        (create-random seed)))
+        (create-random seed))
+
+      [:debug _]
+      (if goog.DEBUG
+        (->DebugTraffic)
+        (throw (ex-info "ERROR: :debug traffic not valid in production builds" {:spec spec}))))
 
     ; Wrap with a validator in debug mode
     goog.DEBUG (->ValidatedTraffic)

--- a/src/main/atc/subs.cljs
+++ b/src/main/atc/subs.cljs
@@ -5,7 +5,7 @@
    [atc.data.core :refer [local-xy]]
    [atc.engine.model :refer [v* vec3]]
    [atc.structures.rolling-history :refer [most-recent-n]]
-   [atc.subs-util :refer [navaids-by-id]]
+   [atc.subs-util :refer [airport-runway-ids navaids-by-id]]
    [atc.util.subs :refer [get-or-identity]]
    [atc.voice.pretty :refer [cleanup-spoken-text]]
    [clojure.math :refer [floor]]
@@ -186,12 +186,7 @@
 (reg-sub
   :game/airport-runway-ids
   :<- [:game/airport]
-  (fn [airport]
-    (when airport
-      (->> airport
-           :runways
-           (mapcat (juxt :start-id :end-id))
-           (into #{})))))
+  :-> airport-runway-ids)
 
 (reg-sub
   :game/runways

--- a/src/main/atc/subs_util.cljc
+++ b/src/main/atc/subs_util.cljc
@@ -2,6 +2,13 @@
   (:require
    [atc.data.core :refer [local-xy]]))
 
+(defn airport-runway-ids [airport]
+  (when airport
+    (->> airport
+         :runways
+         (mapcat (juxt :start-id :end-id))
+         (into #{}))))
+
 (defn navaids-by-id [airport]
   (some->>
     airport

--- a/src/main/atc/util/math.cljc
+++ b/src/main/atc/util/math.cljc
@@ -1,0 +1,3 @@
+(ns atc.util.math)
+
+(defn squared [v] (* v v))

--- a/src/main/atc/util/spec.cljc
+++ b/src/main/atc/util/spec.cljc
@@ -10,4 +10,5 @@
       (tap> value)
       (let [explanation (s/explain-str spec value)]
         (println "Spec check failed: " explanation)
+        (println " value: " value)
         false))))

--- a/src/main/atc/util/testing.cljc
+++ b/src/main/atc/util/testing.cljc
@@ -2,7 +2,7 @@
   (:require
    [atc.data.airports.kjfk :as kjfk]
    [atc.engine.model :refer [v- vec3 vmag]]
-   [atc.subs-util :refer [navaids-by-id]]))
+   [atc.subs-util :refer [airport-runway-ids navaids-by-id]]))
 
 (defn- maybe->vec3
   "Coerce v into a vec3, if it looks vec3-like"
@@ -27,5 +27,6 @@
 
 (defn create-engine []
   {:airport kjfk/airport
+   :game/airport-runway-ids (airport-runway-ids kjfk/airport)
    :game/navaids-by-id (navaids-by-id kjfk/airport)})
 


### PR DESCRIPTION
This PR adds some rough, initial support for clearing aircraft to fly a visual approach!

There's certainly a lot more commands we should support to "fully" handle visual approaches, but this includes the bare minimum "cleared visual runway XX." Includes logic for entering the pattern, flying downwind, turning base, and then turning final and gliding down to the runway threshold.

Also:

- The `(tick)` and and `(command)` methods on the `ISimulated` protocol now both accept an explicit "context." For aircraft, the context should always be the current Engine state; for the `Engine`, we use this param to pass in the "full" command object to `(command)` and it is unused for `(tick)`.
    - We already were passing the engine to aircraft commands in a hacky way, using metadata on the command vector; this change makes that much cleaner.
    - This change enables command handlers (via `tick`) to cleanly query the state of the world---for example, aircraft in a visual approach will differ their base turn if another aircraft is currently in it.
- Adds a `:debug` traffic we can use in dev builds to quickly set up a specific flight for testing flows. This is not available in the UI and must be triggered from the REPL.
- Some fixes for our logic handling the final landing approach, which should apply to the existing ILS approaches, as well.
- Organizationally, we split up the monolithic `commands.cljs` file into a bunch of separate files in the `commands` namespace. This is because the visual approach was quite complicated, so I wanted to give it its own namespace. It depends on pretty much every other command to handle navigation, etc so it was just simplest to give them their own namespaces, as well, in order to avoid having to deal with circular dependencies.

Does not include:

- "Correct" pattern entrance (IE: 45 degree entry to downwind at midfield). If we ever add a "tower" gameplay mode we might want to go back and build that, but for now the current behavior ought to be "good enough"
- Requests to "report" positions in the pattern. Shouldn't be too hard, but it's left to future work.
- Requests to extend the downwind. I did include logic to support such a command in the future but again left it to future work.
- Complaining about failure to handoff to tower. In theory, the airplane should fly missed at some point if we fail to hand it off; the same goes for ILS approaches as well. 